### PR TITLE
feat: Disable `testthat`-related rules in packages that don't use it

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flir
 Type: Package
 Title: Find and Fix Lints in R Code
-Version: 0.4.1
+Version: 0.4.1.9000
 Authors@R:
     person(given = "Etienne",
            family = "Bacher",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# flir (development version)
+
+## Changes
+
+* Linters related to `testthat` (such as `expect_named`) are ignored if the
+  files that are parsed belong to a package that doesn't have a `tests/testthat`
+  folder (for instance if you use `tinytest` instead). (#74)
+
 # flir (0.4.1)
 
 ## Bug fixes

--- a/R/fix.R
+++ b/R/fix.R
@@ -221,7 +221,6 @@ fix_text <- function(
   } else {
     tmp <- tempfile(fileext = ".R")
   }
-
   text <- trimws(text)
   cat(text, file = tmp)
   out <- fix(

--- a/R/fix.R
+++ b/R/fix.R
@@ -221,6 +221,7 @@ fix_text <- function(
   } else {
     tmp <- tempfile(fileext = ".R")
   }
+
   text <- trimws(text)
   cat(text, file = tmp)
   out <- fix(

--- a/R/list-linters.R
+++ b/R/list-linters.R
@@ -1,5 +1,6 @@
 #' Get the list of linters in `flir`
 #'
+#' @inheritParams lint
 #' @return A character vector
 #' @export
 #'

--- a/R/list-linters.R
+++ b/R/list-linters.R
@@ -5,8 +5,8 @@
 #'
 #' @examples
 #' list_linters()
-list_linters <- function() {
-  c(
+list_linters <- function(path = ".") {
+  out <- c(
     # "absolute_path", # TODO: really broken, too many false positives, e.g #42
     "any_duplicated",
     "any_is_na",
@@ -59,11 +59,13 @@ list_linters <- function() {
     "unreachable_code",
     "which_grepl"
   )
+  keep_or_exclude_testthat_rules(path, out)
 }
 
-update_linter_factory <- function() {
+update_linter_factory <- function(path = ".") {
   suppressWarnings(file.remove("R/linters_factory.R"))
-  for (i in list_linters()) {
+  list_linters <- list_linters(path)
+  for (i in list_linters) {
     if (grepl("assignment", i)) {
       cat(
         sprintf(
@@ -102,7 +104,7 @@ makeActiveBinding('%s_linter', function() { function() '%s' }, env = environment
   cat(
     paste0(
       "keep:\n",
-      paste("  -", list_linters(), collapse = "\n")
+      paste("  -", list_linters, collapse = "\n")
     ),
     file = "inst/config.yml"
   )

--- a/R/setup.R
+++ b/R/setup.R
@@ -44,7 +44,7 @@ setup_flir <- function(path = ".") {
   }
   config_content <- paste0(
     "keep:\n",
-    paste("  -", list_linters(), collapse = "\n")
+    paste("  -", list_linters(path), collapse = "\n")
   )
   writeLines(config_content, file.path(flir_dir, "config.yml"))
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -312,7 +312,6 @@ is_r_package <- function(path = ".") {
     rprojroot::find_root(rprojroot::is_r_package, path = path),
     silent = TRUE
   )
-
   !inherits(tr, "try-error")
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -112,6 +112,7 @@ resolve_linters <- function(path, linters, exclude_linters) {
   }
 
   linters <- setdiff(linters, exclude_linters)
+  linters <- keep_or_exclude_testthat_rules(path, linters)
   if (
     !all(linters %in% rules_basename_noext | linter_is_path_to_yml(linters))
   ) {
@@ -306,6 +307,15 @@ is_testing <- function() {
   identical(Sys.getenv("TESTTHAT"), "true")
 }
 
+is_r_package <- function(path = ".") {
+  tr <- try(
+    rprojroot::find_root(rprojroot::is_r_package, path = path),
+    silent = TRUE
+  )
+
+  !inherits(tr, "try-error")
+}
+
 new_rule <- function(name) {
   dest <- paste0("inst/rules/builtin/", name, ".yml")
   cat(
@@ -328,6 +338,40 @@ uses_git <- function() {
   fs::dir_exists(".git")
 }
 
+# By default, we want this to be TRUE if we're not inside a package (e.g.
+# testing on temp files).
+uses_testthat <- function(path = ".") {
+  out <- TRUE
+  testthat_folder_exists <- unname(fs::dir_exists(fs::path(path, "tests", "testthat")))
+  if (is_r_package(path) && !testthat_folder_exists) {
+    out <-  FALSE
+  }
+  out
+}
+
 is_positron <- function() {
   identical(Sys.getenv("POSITRON"), "1")
+}
+
+keep_or_exclude_testthat_rules <- function(path, linters) {
+  if (length(path) > 1) {
+    path <- fs::path_common(fs::path_abs(path))
+  }
+  if (fs::is_file(path)) {
+    path <- fs::path_dir(path)
+  }
+  if (!uses_testthat(path)) {
+    exclude <- c(
+      "expect_comparison",
+      "expect_identical",
+      "expect_length",
+      "expect_named",
+      "expect_not",
+      "expect_null",
+      "expect_true_false",
+      "expect_type"
+    )
+    linters <- setdiff(linters, exclude)
+  }
+  linters
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -341,9 +341,13 @@ uses_git <- function() {
 # testing on temp files).
 uses_testthat <- function(path = ".") {
   out <- TRUE
-  testthat_folder_exists <- unname(fs::dir_exists(fs::path(path, "tests", "testthat")))
+  testthat_folder_exists <- unname(fs::dir_exists(fs::path(
+    path,
+    "tests",
+    "testthat"
+  )))
   if (is_r_package(path) && !testthat_folder_exists) {
-    out <-  FALSE
+    out <- FALSE
   }
   out
 }

--- a/man/list_linters.Rd
+++ b/man/list_linters.Rd
@@ -4,7 +4,11 @@
 \alias{list_linters}
 \title{Get the list of linters in \code{flir}}
 \usage{
-list_linters()
+list_linters(path = ".")
+}
+\arguments{
+\item{path}{A valid path to a file or a directory. Relative paths are
+accepted.}
 }
 \value{
 A character vector

--- a/tests/testthat/test-list_linters.R
+++ b/tests/testthat/test-list_linters.R
@@ -1,0 +1,30 @@
+test_that("expect_*() rules are only present if the package uses testthat", {
+  create_local_package()
+  expect_rules <- grep("^expect\\_", list_linters(), value = TRUE)
+  expect_length(expect_rules, 0)
+
+  suppressMessages(usethis::use_testthat())
+  expect_rules <- grep("^expect\\_", list_linters(), value = TRUE)
+  expect_true(length(expect_rules) > 0)
+})
+
+test_that("expect_*() rules are only used if the package uses testthat", {
+  create_local_package()
+  fs::dir_create("inst/tinytest")
+
+  cat(
+    "expect_equal(names(x), c('a', 'b'))\n",
+    file = "inst/tinytest/test-foo.R"
+  )
+
+  # lint() skips expect_* linters for tinytest
+  expect_true(nrow(lint_package(open = FALSE)) == 0)
+  expect_true(nrow(lint("inst/tinytest/test-foo.R", open = FALSE)) == 0)
+
+  # fix() leaves that unchanged
+  fix("inst/tinytest/test-foo.R")
+  expect_equal(
+    readLines("inst/tinytest/test-foo.R"),
+    "expect_equal(names(x), c('a', 'b'))"
+  )
+})


### PR DESCRIPTION
This will only disable those linters if the path belongs to a package and there's no folder `tests/testthat` in this package. 

Fixes #71