### PR TITLE
feat: Deactivate `unreachable_code` by default (still opt-in)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flir
 Type: Package
 Title: Find and Fix Lints in R Code
-Version: 0.4.2
+Version: 0.4.2.9000
 Authors@R:
     person(given = "Etienne",
            family = "Bacher",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# flir (development version)
+
+## Changes
+
+* `unreachable_code` is deactivated by default. It can still be activated with
+  the argument `linters` or in `flir/config.yml` after running `setup_flir()` 
+  (#75).
+
 # flir 0.4.2
 
 ## Changes

--- a/R/list-linters.R
+++ b/R/list-linters.R
@@ -57,7 +57,9 @@ list_linters <- function(path = ".") {
     "undesirable_function",
     "undesirable_operator",
     "unnecessary_nesting",
-    "unreachable_code",
+    # TODO: I think it should be removed eventually, ast-grep tools is just not
+    # the right tool for this. For now, I just leave it opt-in.
+    # "unreachable_code",
     "which_grepl"
   )
   keep_or_exclude_testthat_rules(path, out)

--- a/R/utils.R
+++ b/R/utils.R
@@ -113,6 +113,17 @@ resolve_linters <- function(path, linters, exclude_linters) {
 
   linters <- setdiff(linters, exclude_linters)
   linters <- keep_or_exclude_testthat_rules(path, linters)
+
+  # Ignore unreachable_code in tests
+  if (is_flir_package(path)) {
+    linters <- linters[grep(
+      "unreachable_code",
+      linters,
+      fixed = TRUE,
+      invert = TRUE
+    )]
+  }
+
   if (
     !all(linters %in% rules_basename_noext | linter_is_path_to_yml(linters))
   ) {

--- a/inst/config.yml
+++ b/inst/config.yml
@@ -47,5 +47,6 @@ keep:
   - undesirable_function
   - undesirable_operator
   - unnecessary_nesting
-  - unreachable_code
+  # This can be activated, but it is slow.
+  # - unreachable_code
   - which_grepl

--- a/tests/testthat/test-unreachable_code.R
+++ b/tests/testthat/test-unreachable_code.R
@@ -539,3 +539,22 @@ test_that("Do not lint inline else after stop in inline function", {
 #   expect_lint("\\(x) if (x > 3L) stop() else x + 3", NULL, linter)
 #   expect_lint("\\(x){ if (x > 3L) stop() else x + 3 }", NULL, linter)
 # })
+
+test_that("unreachable_code is deactivated by default", {
+  expect_lint(
+    "foo <- function(bar) { \nreturn(bar)\n 1 + 1}",
+    "Code and comments coming after",
+    unreachable_code_linter()
+  )
+  expect_lint(
+    "foo <- function(bar) { \nreturn(bar)\n 1 + 1}",
+    NULL,
+    NULL
+  )
+
+  create_local_package()
+  setup_flir()
+  cat("foo <- function(bar) { \nreturn(bar)\n 1 + 1}", file = "R/foo.R")
+  lints <- lint_package()
+  expect_equal(nrow(lints), 0)
+})


### PR DESCRIPTION
Fixes #59 

This is slow and I'm now quite convinced ast-grep is not the right tool for this. This would need more advanced semantic analysis.