### PR TITLE
fix: Ignore `T_and_F_symbol` in `:` operation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 * `unreachable_code` is deactivated by default. It can still be activated with
   the argument `linters` or in `flir/config.yml` after running `setup_flir()` 
   (#75).
+* `T_and_F_symbol` do not detect anymore the use of `F` and `T` when those are
+  used in the `:` operation (#81).
 
 # flir 0.4.2
 

--- a/inst/rules/builtin/T_and_F_symbol.yml
+++ b/inst/rules/builtin/T_and_F_symbol.yml
@@ -11,9 +11,11 @@ rule:
             - pattern: <-
             - pattern: =
             - regex: ^~$
+            - regex: ^:$
       - follows:
           any:
             - pattern: $
+            - regex: ^:$
             - regex: ^~$
       - inside:
           any:
@@ -44,10 +46,12 @@ rule:
             - pattern: <-
             - pattern: =
             - regex: ^~$
+            - regex: ^:$
       - follows:
           any:
             - pattern: $
             - regex: ^~$
+            - regex: ^:$
       - inside:
           any:
             - kind: parameter

--- a/tests/testthat/test-T_and_F_symbol.R
+++ b/tests/testthat/test-T_and_F_symbol.R
@@ -26,6 +26,17 @@ test_that("T_and_F_symbol_linter is correct in formulas", {
   )
 })
 
+# https://github.com/etiennebacher/flir/issues/80
+test_that("T_and_F_symbol_linter not applied if part of `:`", {
+  linter <- T_and_F_symbol_linter()
+
+  expect_lint("A:T", NULL, linter)
+  expect_lint("A:F", NULL, linter)
+  expect_lint("T:A", NULL, linter)
+  expect_lint("F:A", NULL, linter)
+  expect_lint("f(F:A)", NULL, linter)
+})
+
 test_that("T_and_F_symbol_linter blocks disallowed usages", {
   linter <- T_and_F_symbol_linter()
   msg_true <- "Use TRUE instead of the symbol T."


### PR DESCRIPTION
Fixes #80 