### PR TITLE
fix: Use `path = "."` by default in `list_linters()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 * When using external rules with the `with-<pkg>` syntax, if the YAML file
   contains several rules separated by "---", then `flir` would only use the 
   first one. This is now fixed (#95). 
+  
+* `list_linters()` now uses `path = "."` by default (#99).
 
 # flir 0.5.0
 

--- a/R/lint.R
+++ b/R/lint.R
@@ -11,7 +11,7 @@
 #' `demo`, `exec`.
 #'
 #' @param path A valid path to a file or a directory. Relative paths are
-#'   accepted. If `NULL` (default), uses `"."`.
+#'   accepted. Default is `"."`.
 #' @param linters A character vector with the names of the rules to apply. See
 #'   the entire list of rules with `list_linters()`. If you have set up the
 #'   `flir` folder with `setup_flir()`, you can also list the linters to use

--- a/R/list-linters.R
+++ b/R/list-linters.R
@@ -6,10 +6,7 @@
 #'
 #' @examples
 #' list_linters(".")
-list_linters <- function(path) {
-  if (missing(path) && is_testing()) {
-    path <- "."
-  }
+list_linters <- function(path = ".") {
   out <- c(
     # "absolute_path", # TODO: really broken, too many false positives, e.g #42
     "any_duplicated",

--- a/man/lint.Rd
+++ b/man/lint.Rd
@@ -41,7 +41,7 @@ lint_text(text, linters = NULL, exclude_linters = NULL)
 }
 \arguments{
 \item{path}{A valid path to a file or a directory. Relative paths are
-accepted. If \code{NULL} (default), uses \code{"."}.}
+accepted. Default is \code{"."}.}
 
 \item{linters}{A character vector with the names of the rules to apply. See
 the entire list of rules with \code{list_linters()}. If you have set up the

--- a/man/list_linters.Rd
+++ b/man/list_linters.Rd
@@ -4,11 +4,11 @@
 \alias{list_linters}
 \title{Get the list of linters in \code{flir}}
 \usage{
-list_linters(path)
+list_linters(path = ".")
 }
 \arguments{
 \item{path}{A valid path to a file or a directory. Relative paths are
-accepted. If \code{NULL} (default), uses \code{"."}.}
+accepted. Default is \code{"."}.}
 }
 \value{
 A character vector


### PR DESCRIPTION
Fixes #98 