### PR TITLE
refactor: Use `expect_no_lint()` instead of `expect_lint(..., NULL, ...)`

### DIFF
--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -20,6 +20,10 @@ expect_lint <- function(x, message, linter, ...) {
   }
 }
 
+expect_no_lint <- function(x, linter, ...) {
+  expect_lint(x, message = NULL, linter, ...)
+}
+
 expect_fix <- function(x, replacement, ...) {
   out <- fix_text(x, ...)
   testthat::expect_equal(as.character(out), replacement)

--- a/tests/testthat/test-T_and_F_symbol.R
+++ b/tests/testthat/test-T_and_F_symbol.R
@@ -1,23 +1,23 @@
 test_that("T_and_F_symbol_linter skips allowed usages", {
   linter <- T_and_F_symbol_linter()
 
-  expect_lint("FALSE", NULL, linter)
-  expect_lint("TRUE", NULL, linter)
-  expect_lint("F()", NULL, linter)
-  expect_lint("T()", NULL, linter)
-  expect_lint("x <- \"TRUE a vs FALSE b\"", NULL, linter)
+  expect_no_lint("FALSE", linter)
+  expect_no_lint("TRUE", linter)
+  expect_no_lint("F()", linter)
+  expect_no_lint("T()", linter)
+  expect_no_lint("x <- \"TRUE a vs FALSE b\"", linter)
 })
 
 test_that("T_and_F_symbol_linter is correct in formulas", {
   linter <- T_and_F_symbol_linter()
 
-  expect_lint("lm(weight ~ T, data)", NULL, linter)
-  expect_lint("lm(weight ~ F, data)", NULL, linter)
-  expect_lint("lm(weight ~ T + var, data)", NULL, linter)
-  expect_lint("lm(weight ~ A + T | var, data)", NULL, linter)
-  expect_lint("lm(weight ~ var | A + T, data)", NULL, linter)
-  expect_lint("lm(weight ~ var + var2 + T, data)", NULL, linter)
-  expect_lint("lm(T ~ weight, data)", NULL, linter)
+  expect_no_lint("lm(weight ~ T, data)", linter)
+  expect_no_lint("lm(weight ~ F, data)", linter)
+  expect_no_lint("lm(weight ~ T + var, data)", linter)
+  expect_no_lint("lm(weight ~ A + T | var, data)", linter)
+  expect_no_lint("lm(weight ~ var | A + T, data)", linter)
+  expect_no_lint("lm(weight ~ var + var2 + T, data)", linter)
+  expect_no_lint("lm(T ~ weight, data)", linter)
 
   expect_lint(
     "lm(weight ~ var + foo(x, arg = T), data)",
@@ -30,11 +30,11 @@ test_that("T_and_F_symbol_linter is correct in formulas", {
 test_that("T_and_F_symbol_linter not applied if part of `:`", {
   linter <- T_and_F_symbol_linter()
 
-  expect_lint("A:T", NULL, linter)
-  expect_lint("A:F", NULL, linter)
-  expect_lint("T:A", NULL, linter)
-  expect_lint("F:A", NULL, linter)
-  expect_lint("f(F:A)", NULL, linter)
+  expect_no_lint("A:T", linter)
+  expect_no_lint("A:F", linter)
+  expect_no_lint("T:A", linter)
+  expect_no_lint("F:A", linter)
+  expect_no_lint("f(F:A)", linter)
 })
 
 test_that("T_and_F_symbol_linter blocks disallowed usages", {
@@ -44,7 +44,7 @@ test_that("T_and_F_symbol_linter blocks disallowed usages", {
   msg_variable_true <- "Don't use T as a variable name, as it can break code relying on T being TRUE."
   msg_variable_false <- "Don't use F as a variable name, as it can break code relying on F being FALSE."
 
-  expect_lint("'T <- 1'", NULL, linter)
+  expect_no_lint("'T <- 1'", linter)
   expect_lint("T", msg_true, linter)
   expect_lint("F", msg_false, linter)
   expect_lint("T = 42", msg_variable_true, linter)
@@ -107,19 +107,19 @@ test_that("T_and_F_symbol_linter blocks disallowed usages", {
 
 test_that("T_and_F_symbol_linter doesn't block variables called T or F", {
   linter <- T_and_F_symbol_linter()
-  expect_lint("mtcars$F", NULL, linter)
-  expect_lint("mtcars$T", NULL, linter)
+  expect_no_lint("mtcars$F", linter)
+  expect_no_lint("mtcars$T", linter)
 })
 
 test_that("do not block parameters named T/F", {
   linter <- T_and_F_symbol_linter()
-  expect_lint("myfun <- function(T) {}", NULL, linter)
-  expect_lint("myfun <- function(F) {}", NULL, linter)
+  expect_no_lint("myfun <- function(T) {}", linter)
+  expect_no_lint("myfun <- function(F) {}", linter)
 })
 
 test_that("do not block vector names T/F", {
   linter <- T_and_F_symbol_linter()
-  expect_lint("c(T = 'foo', F = 'foo')", NULL, linter)
+  expect_no_lint("c(T = 'foo', F = 'foo')", linter)
 })
 
 test_that("don't replace T/F when they receive the assignment", {

--- a/tests/testthat/test-any_duplicated.R
+++ b/tests/testthat/test-any_duplicated.R
@@ -1,8 +1,8 @@
 test_that("any_duplicated_linter skips allowed usages", {
   linter <- any_duplicated_linter()
 
-  expect_lint("x <- any(y)", NULL, linter)
-  expect_lint("y <- duplicated(z)", NULL, linter)
+  expect_no_lint("x <- any(y)", linter)
+  expect_no_lint("y <- duplicated(z)", linter)
 })
 
 test_that("any_duplicated_linter blocks simple disallowed usages", {
@@ -30,10 +30,10 @@ test_that("any_duplicated_linter catches length(unique()) equivalencies too", {
 
   # non-matches
   ## different variable
-  expect_lint("length(unique(x)) == length(y)", NULL, linter)
+  expect_no_lint("length(unique(x)) == length(y)", linter)
   ## different table
-  expect_lint("length(unique(DF$x)) == nrow(DT)", NULL, linter)
-  expect_lint("length(unique(l1$DF$x)) == nrow(l2$DF)", NULL, linter)
+  expect_no_lint("length(unique(DF$x)) == nrow(DT)", linter)
+  expect_no_lint("length(unique(l1$DF$x)) == nrow(l2$DF)", linter)
 
   # lintable usage
   expect_lint("length(unique(x)) == length(x)", lint_msg_x, linter)

--- a/tests/testthat/test-any_is_na.R
+++ b/tests/testthat/test-any_is_na.R
@@ -3,16 +3,16 @@ lint_message <- "anyNA(x) is better than any(is.na(x))."
 test_that("any_is_na_linter skips allowed usages", {
   linter <- any_is_na_linter()
 
-  expect_lint("x <- any(y)", NULL, linter)
-  expect_lint("y <- is.na(z)", NULL, linter)
+  expect_no_lint("x <- any(y)", linter)
+  expect_no_lint("y <- is.na(z)", linter)
 
   # negation shouldn't list
-  expect_lint("any(!is.na(x))", NULL, linter)
-  expect_lint("any(!is.na(foo(x)))", NULL, linter)
+  expect_no_lint("any(!is.na(x))", linter)
+  expect_no_lint("any(!is.na(foo(x)))", linter)
 
   # extended usage of ... arguments to any is not covered
-  expect_lint("any(is.na(y), b)", NULL, linter)
-  expect_lint("any(b, is.na(y))", NULL, linter)
+  expect_no_lint("any(is.na(y), b)", linter)
+  expect_no_lint("any(b, is.na(y))", linter)
 })
 
 test_that("any_is_na_linter blocks disallowed usages", {
@@ -34,5 +34,5 @@ test_that("NA %in% x is also found", {
 
   expect_lint("NA %in% x", lint_message, linter)
   expect_lint("NA_real_ %in% x", lint_message, linter)
-  expect_lint("NA_not_a_sentinel_ %in% x", NULL, linter)
+  expect_no_lint("NA_not_a_sentinel_ %in% x", linter)
 })

--- a/tests/testthat/test-assignment_linter.R
+++ b/tests/testthat/test-assignment_linter.R
@@ -1,10 +1,10 @@
 test_that("assignment_linter skips allowed usages", {
   linter <- NULL
 
-  expect_lint("blah", NULL, linter)
-  expect_lint("blah <- 1", NULL, linter)
-  expect_lint("blah<-1", NULL, linter)
-  expect_lint("fun(blah=1)", NULL, linter)
+  expect_no_lint("blah", linter)
+  expect_no_lint("blah <- 1", linter)
+  expect_no_lint("blah<-1", linter)
+  expect_no_lint("fun(blah=1)", linter)
 })
 
 test_that("assignment_linter blocks disallowed usages", {

--- a/tests/testthat/test-class_equals.R
+++ b/tests/testthat/test-class_equals.R
@@ -1,19 +1,19 @@
 test_that("class_equals_linter skips allowed usages", {
   linter <- class_equals_linter()
 
-  expect_lint("class(x) <- 'character'", NULL, linter)
-  expect_lint("class(x) = 'character'", NULL, linter)
+  expect_no_lint("class(x) <- 'character'", linter)
+  expect_no_lint("class(x) = 'character'", linter)
 
   # proper way to test exact class
-  expect_lint("identical(class(x), c('glue', 'character'))", NULL, linter)
-  expect_lint("is_lm <- inherits(x, 'lm')", NULL, linter)
+  expect_no_lint("identical(class(x), c('glue', 'character'))", linter)
+  expect_no_lint("is_lm <- inherits(x, 'lm')", linter)
 })
 
 # https://github.com/vincentarelbundock/marginaleffects/pull/1171#issuecomment-2228497287
 # inherits() returns TRUE if any of the classes match
 test_that("all(inherits()) not the same as all(x %in% y)", {
   linter <- class_equals_linter()
-  expect_lint("isTRUE(all(sup %in% class(model)))", NULL, linter)
+  expect_no_lint("isTRUE(all(sup %in% class(model)))", linter)
 })
 
 test_that("class_equals_linter blocks simple disallowed usages", {
@@ -51,7 +51,7 @@ test_that("class_equals_linter blocks class(x) != 'klass'", {
 test_that("class_equals_linter skips usage for subsetting", {
   linter <- class_equals_linter()
 
-  expect_lint("class(x)[class(x) == 'foo']", NULL, linter)
+  expect_no_lint("class(x)[class(x) == 'foo']", linter)
 
   # but not further nesting
   expect_lint(

--- a/tests/testthat/test-condition_message.R
+++ b/tests/testthat/test-condition_message.R
@@ -14,7 +14,8 @@ test_that("condition_message_linter skips allowed usages", {
   expect_no_lint("stop(sprintf('A %s!', 'string'))", linter)
 
   # get multiple sep= in one expression
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       tryCatch(
         foo(x),
@@ -22,13 +23,18 @@ test_that("condition_message_linter skips allowed usages", {
         warning = function(w) warning(paste0(a, b, recycle0 = TRUE)),
       )
     "
-    ), linter)
+    ),
+    linter
+  )
 })
 
 skip_if_not_installed("tibble")
 patrick::with_parameters_test_that(
   "paste/paste allowed by condition_message_linter when using other seps and/or collapse",
-  expect_no_lint(sprintf("%s(%s(x, %s = '%s'))", condition, fun, parameter, arg), condition_message_linter()),
+  expect_no_lint(
+    sprintf("%s(%s(x, %s = '%s'))", condition, fun, parameter, arg),
+    condition_message_linter()
+  ),
   .cases = tibble::tribble(
     ~.test_name,
     ~condition,
@@ -72,7 +78,10 @@ patrick::with_parameters_test_that(
 )
 
 test_that("do not block usage of paste()", {
-  expect_no_lint("stop(paste('a string', 'another'))", condition_message_linter())
+  expect_no_lint(
+    "stop(paste('a string', 'another'))",
+    condition_message_linter()
+  )
 })
 
 test_that("condition_message_linter blocks simple disallowed usages", {
@@ -137,7 +146,10 @@ test_that("packageStartupMessage usages are also matched", {
     condition_message_linter()
   )
 
-  expect_no_lint("packageStartupMessage(paste('a string ', 'another'))", condition_message_linter())
+  expect_no_lint(
+    "packageStartupMessage(paste('a string ', 'another'))",
+    condition_message_linter()
+  )
 })
 
 # test_that("R>=4.0.0 raw strings are handled", {

--- a/tests/testthat/test-condition_message.R
+++ b/tests/testthat/test-condition_message.R
@@ -1,21 +1,20 @@
 test_that("condition_message_linter skips allowed usages", {
   linter <- condition_message_linter()
 
-  expect_lint("stop('a string', 'another')", NULL, linter)
-  expect_lint("warning('a string', 'another')", NULL, linter)
-  expect_lint("message('a string', 'another')", NULL, linter)
+  expect_no_lint("stop('a string', 'another')", linter)
+  expect_no_lint("warning('a string', 'another')", linter)
+  expect_no_lint("message('a string', 'another')", linter)
   # extracted calls likely don't obey base::stop() semantics
-  expect_lint("ctx$stop(paste0('a', 'b'))", NULL, linter)
-  expect_lint("ctx@stop(paste0('a', 'b'))", NULL, linter)
+  expect_no_lint("ctx$stop(paste0('a', 'b'))", linter)
+  expect_no_lint("ctx@stop(paste0('a', 'b'))", linter)
 
-  expect_lint("format_warning(paste0('a', 'b'))", NULL, linter)
+  expect_no_lint("format_warning(paste0('a', 'b'))", linter)
 
   # sprintf is OK -- gettextf() enforcement is left to other linters
-  expect_lint("stop(sprintf('A %s!', 'string'))", NULL, linter)
+  expect_no_lint("stop(sprintf('A %s!', 'string'))", linter)
 
   # get multiple sep= in one expression
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       tryCatch(
         foo(x),
@@ -23,20 +22,13 @@ test_that("condition_message_linter skips allowed usages", {
         warning = function(w) warning(paste0(a, b, recycle0 = TRUE)),
       )
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 })
 
 skip_if_not_installed("tibble")
 patrick::with_parameters_test_that(
   "paste/paste allowed by condition_message_linter when using other seps and/or collapse",
-  expect_lint(
-    sprintf("%s(%s(x, %s = '%s'))", condition, fun, parameter, arg),
-    NULL,
-    condition_message_linter()
-  ),
+  expect_no_lint(sprintf("%s(%s(x, %s = '%s'))", condition, fun, parameter, arg), condition_message_linter()),
   .cases = tibble::tribble(
     ~.test_name,
     ~condition,
@@ -80,11 +72,7 @@ patrick::with_parameters_test_that(
 )
 
 test_that("do not block usage of paste()", {
-  expect_lint(
-    "stop(paste('a string', 'another'))",
-    NULL,
-    condition_message_linter()
-  )
+  expect_no_lint("stop(paste('a string', 'another'))", condition_message_linter())
 })
 
 test_that("condition_message_linter blocks simple disallowed usages", {
@@ -149,11 +137,7 @@ test_that("packageStartupMessage usages are also matched", {
     condition_message_linter()
   )
 
-  expect_lint(
-    "packageStartupMessage(paste('a string ', 'another'))",
-    NULL,
-    condition_message_linter()
-  )
+  expect_no_lint("packageStartupMessage(paste('a string ', 'another'))", condition_message_linter())
 })
 
 # test_that("R>=4.0.0 raw strings are handled", {

--- a/tests/testthat/test-duplicate_argument.R
+++ b/tests/testthat/test-duplicate_argument.R
@@ -74,23 +74,32 @@ test_that("duplicate_argument_linter blocks disallowed usages", {
 test_that("doesn't lint duplicated arguments in allowed functions", {
   linter <- duplicate_argument_linter()
 
-  expect_no_lint("x %>%
+  expect_no_lint(
+    "x %>%
      dplyr::mutate(
        col = a + b,
        col = col + d
-     )", linter)
+     )",
+    linter
+  )
 
-  expect_no_lint("x %>%
+  expect_no_lint(
+    "x %>%
      dplyr::transmute(
        col = a + b,
        col = col / 2.5
-     )", linter)
+     )",
+    linter
+  )
 
   skip_if_not_r_version("4.1.0")
-  expect_no_lint("x |>
+  expect_no_lint(
+    "x |>
     dplyr::mutate(
       col = col |> str_replace('t', '') |> str_replace('\\\\s+$', 'xxx')
-    )", linter)
+    )",
+    linter
+  )
 })
 
 test_that("interceding comments don't trip up logic", {

--- a/tests/testthat/test-duplicate_argument.R
+++ b/tests/testthat/test-duplicate_argument.R
@@ -1,12 +1,12 @@
 test_that("duplicate_argument_linter doesn't block allowed usages", {
   linter <- duplicate_argument_linter()
 
-  expect_lint("fun(arg = 1)", NULL, linter)
-  expect_lint("fun('arg' = 1)", NULL, linter)
-  expect_lint("fun(`arg` = 1)", NULL, linter)
-  expect_lint("'fun'(arg = 1)", NULL, linter)
-  expect_lint("(function(x, y) x + y)(x = 1)", NULL, linter)
-  expect_lint("dt[i = 1]", NULL, linter)
+  expect_no_lint("fun(arg = 1)", linter)
+  expect_no_lint("fun('arg' = 1)", linter)
+  expect_no_lint("fun(`arg` = 1)", linter)
+  expect_no_lint("'fun'(arg = 1)", linter)
+  expect_no_lint("(function(x, y) x + y)(x = 1)", linter)
+  expect_no_lint("dt[i = 1]", linter)
 })
 
 test_that("duplicate_argument_linter blocks disallowed usages", {
@@ -74,35 +74,23 @@ test_that("duplicate_argument_linter blocks disallowed usages", {
 test_that("doesn't lint duplicated arguments in allowed functions", {
   linter <- duplicate_argument_linter()
 
-  expect_lint(
-    "x %>%
+  expect_no_lint("x %>%
      dplyr::mutate(
        col = a + b,
        col = col + d
-     )",
-    NULL,
-    linter
-  )
+     )", linter)
 
-  expect_lint(
-    "x %>%
+  expect_no_lint("x %>%
      dplyr::transmute(
        col = a + b,
        col = col / 2.5
-     )",
-    NULL,
-    linter
-  )
+     )", linter)
 
   skip_if_not_r_version("4.1.0")
-  expect_lint(
-    "x |>
+  expect_no_lint("x |>
     dplyr::mutate(
       col = col |> str_replace('t', '') |> str_replace('\\\\s+$', 'xxx')
-    )",
-    NULL,
-    linter
-  )
+    )", linter)
 })
 
 test_that("interceding comments don't trip up logic", {
@@ -289,6 +277,6 @@ test_that("lints vectorize", {
 test_that("do not block when argument values and argument names are duplicated", {
   linter <- duplicate_argument_linter()
 
-  expect_lint("fun(arg = x, x = 1)", NULL, linter)
-  expect_lint("intersect(names(a), names(b))", NULL, linter)
+  expect_no_lint("fun(arg = x, x = 1)", linter)
+  expect_no_lint("intersect(names(a), names(b))", linter)
 })

--- a/tests/testthat/test-empty_assignment.R
+++ b/tests/testthat/test-empty_assignment.R
@@ -1,9 +1,9 @@
 test_that("empty_assignment_linter skips valid usage", {
-  expect_lint("x <- { 3 + 4 }", NULL, empty_assignment_linter())
-  expect_lint("x <- if (x > 1) { 3 + 4 }", NULL, empty_assignment_linter())
+  expect_no_lint("x <- { 3 + 4 }", empty_assignment_linter())
+  expect_no_lint("x <- if (x > 1) { 3 + 4 }", empty_assignment_linter())
 
   # also triggers assignment_linter
-  expect_lint("x = { 3 + 4 }", NULL, empty_assignment_linter())
+  expect_no_lint("x = { 3 + 4 }", empty_assignment_linter())
 })
 
 test_that("empty_assignment_linter blocks disallowed usages", {

--- a/tests/testthat/test-equals_na.R
+++ b/tests/testthat/test-equals_na.R
@@ -1,31 +1,23 @@
 test_that("equals_na_linter skips allowed usages", {
   linter <- equals_na_linter()
 
-  expect_lint("blah", NULL, linter)
-  expect_lint("  blah", NULL, linter)
-  expect_lint("  blah", NULL, linter)
-  expect_lint("x == 'NA'", NULL, linter)
-  expect_lint("x <- NA", NULL, linter)
-  expect_lint("x <- NaN", NULL, linter)
-  expect_lint("x <- NA_real_", NULL, linter)
-  expect_lint("is.na(x)", NULL, linter)
-  expect_lint("is.nan(x)", NULL, linter)
-  expect_lint("x[!is.na(x)]", NULL, linter)
+  expect_no_lint("blah", linter)
+  expect_no_lint("  blah", linter)
+  expect_no_lint("  blah", linter)
+  expect_no_lint("x == 'NA'", linter)
+  expect_no_lint("x <- NA", linter)
+  expect_no_lint("x <- NaN", linter)
+  expect_no_lint("x <- NA_real_", linter)
+  expect_no_lint("is.na(x)", linter)
+  expect_no_lint("is.nan(x)", linter)
+  expect_no_lint("x[!is.na(x)]", linter)
 
   # equals_na_linter should ignore strings and comments
-  expect_lint(
-    "is.na(x) # do not flag x == NA if inside a comment",
-    NULL,
-    linter
-  )
-  expect_lint(
-    "lint_msg <- 'do not flag x == NA if inside a string'",
-    NULL,
-    linter
-  )
+  expect_no_lint("is.na(x) # do not flag x == NA if inside a comment", linter)
+  expect_no_lint("lint_msg <- 'do not flag x == NA if inside a string'", linter)
 
   # nested NAs are okay
-  expect_lint("x==f(1, ignore = NA)", NULL, linter)
+  expect_no_lint("x==f(1, ignore = NA)", linter)
 })
 
 skip_if_not_installed("tibble")

--- a/tests/testthat/test-exclude_linters.R
+++ b/tests/testthat/test-exclude_linters.R
@@ -1,5 +1,9 @@
 test_that("lint: argument 'exclude_linters' works", {
-  expect_no_lint("any(duplicated(x))", linter = NULL, exclude_linters = "any_duplicated")
+  expect_no_lint(
+    "any(duplicated(x))",
+    linter = NULL,
+    exclude_linters = "any_duplicated"
+  )
 })
 
 test_that("fix: argument 'exclude_linters' works", {

--- a/tests/testthat/test-exclude_linters.R
+++ b/tests/testthat/test-exclude_linters.R
@@ -1,10 +1,5 @@
 test_that("lint: argument 'exclude_linters' works", {
-  expect_lint(
-    "any(duplicated(x))",
-    NULL,
-    linter = NULL,
-    exclude_linters = "any_duplicated"
-  )
+  expect_no_lint("any(duplicated(x))", linter = NULL, exclude_linters = "any_duplicated")
 })
 
 test_that("fix: argument 'exclude_linters' works", {

--- a/tests/testthat/test-expect_comparison.R
+++ b/tests/testthat/test-expect_comparison.R
@@ -2,22 +2,18 @@ test_that("expect_comparison_linter skips allowed usages", {
   linter <- expect_comparison_linter()
 
   # there's no expect_ne() for this operator
-  expect_lint("expect_true(x != y)", NULL, linter)
+  expect_no_lint("expect_true(x != y)", linter)
   # NB: also applies to tinytest, but it's sufficient to test testthat
-  expect_lint("testthat::expect_true(x != y)", NULL, linter)
+  expect_no_lint("testthat::expect_true(x != y)", linter)
 
   # multiple comparisons are OK
-  expect_lint("expect_true(x > y || x > z)", NULL, linter)
+  expect_no_lint("expect_true(x > y || x > z)", linter)
 
   # expect_gt() and friends don't have an info= argument
-  expect_lint(
-    "expect_true(x > y, info = 'x is bigger than y yo')",
-    NULL,
-    linter
-  )
+  expect_no_lint("expect_true(x > y, info = 'x is bigger than y yo')", linter)
 
   # expect_true() used incorrectly, and as executed the first argument is not a lint
-  expect_lint("expect_true(is.count(n_draws), n_draws > 1)", NULL, linter)
+  expect_no_lint("expect_true(is.count(n_draws), n_draws > 1)", linter)
 })
 
 test_that("expect_comparison_linter blocks simple disallowed usages", {

--- a/tests/testthat/test-expect_identical.R
+++ b/tests/testthat/test-expect_identical.R
@@ -4,7 +4,10 @@ test_that("expect_identical_linter skips allowed usages", {
   # expect_type doesn't have an inverted version
   expect_no_lint("expect_true(identical(x, y) || identical(y, z))", linter)
   # NB: also applies to tinytest, but it's sufficient to test testthat
-  expect_no_lint("testthat::expect_true(identical(x, y) || identical(y, z))", linter)
+  expect_no_lint(
+    "testthat::expect_true(identical(x, y) || identical(y, z))",
+    linter
+  )
 
   # expect_equal calls with explicit tolerance= are OK
   expect_no_lint("expect_equal(x, y, tolerance = 1e-6)", linter)
@@ -50,7 +53,10 @@ test_that("expect_identical_linter skips cases likely testing numeric equality",
 })
 
 test_that("expect_identical_linter skips 3e cases needing expect_equal", {
-  expect_no_lint("expect_equal(x, y, ignore_attr = 'names')", expect_identical_linter())
+  expect_no_lint(
+    "expect_equal(x, y, ignore_attr = 'names')",
+    expect_identical_linter()
+  )
 })
 
 # this arose where a helper function was wrapping expect_equal() and

--- a/tests/testthat/test-expect_identical.R
+++ b/tests/testthat/test-expect_identical.R
@@ -2,21 +2,17 @@ test_that("expect_identical_linter skips allowed usages", {
   linter <- expect_identical_linter()
 
   # expect_type doesn't have an inverted version
-  expect_lint("expect_true(identical(x, y) || identical(y, z))", NULL, linter)
+  expect_no_lint("expect_true(identical(x, y) || identical(y, z))", linter)
   # NB: also applies to tinytest, but it's sufficient to test testthat
-  expect_lint(
-    "testthat::expect_true(identical(x, y) || identical(y, z))",
-    NULL,
-    linter
-  )
+  expect_no_lint("testthat::expect_true(identical(x, y) || identical(y, z))", linter)
 
   # expect_equal calls with explicit tolerance= are OK
-  expect_lint("expect_equal(x, y, tolerance = 1e-6)", NULL, linter)
+  expect_no_lint("expect_equal(x, y, tolerance = 1e-6)", linter)
   # ditto if the argument is passed quoted
-  expect_lint("expect_equal(x, y, 'tolerance' = 1e-6)", NULL, linter)
+  expect_no_lint("expect_equal(x, y, 'tolerance' = 1e-6)", linter)
 
   # ditto for check.attributes = FALSE
-  expect_lint("expect_equal(x, y, check.attributes = FALSE)", NULL, linter)
+  expect_no_lint("expect_equal(x, y, check.attributes = FALSE)", linter)
 })
 
 test_that("expect_identical_linter blocks simple disallowed usages", {
@@ -33,14 +29,14 @@ test_that("expect_identical_linter skips cases likely testing numeric equality",
   linter <- expect_identical_linter()
   lint_msg <- "Use expect_identical(x, y) by default; resort to expect_equal()"
 
-  expect_lint("expect_equal(x, 1.034)", NULL, linter)
-  expect_lint("expect_equal(x, -1.034)", NULL, linter)
-  expect_lint("expect_equal(x, c(-1.034))", NULL, linter)
-  expect_lint("expect_equal(x, -c(1.034))", NULL, linter)
+  expect_no_lint("expect_equal(x, 1.034)", linter)
+  expect_no_lint("expect_equal(x, -1.034)", linter)
+  expect_no_lint("expect_equal(x, c(-1.034))", linter)
+  expect_no_lint("expect_equal(x, -c(1.034))", linter)
 
-  expect_lint("expect_equal(x, c(1.01, 1.02))", NULL, linter)
+  expect_no_lint("expect_equal(x, c(1.01, 1.02))", linter)
   # whole numbers with explicit decimals are OK, even in mixed scenarios
-  expect_lint("expect_equal(x, c(1.0, 2))", NULL, linter)
+  expect_no_lint("expect_equal(x, c(1.0, 2))", linter)
   # plain numbers are still caught, however
   expect_lint("expect_equal(x, 1L)", lint_msg, linter)
   expect_lint("expect_equal(x, 1)", lint_msg, linter)
@@ -54,17 +50,13 @@ test_that("expect_identical_linter skips cases likely testing numeric equality",
 })
 
 test_that("expect_identical_linter skips 3e cases needing expect_equal", {
-  expect_lint(
-    "expect_equal(x, y, ignore_attr = 'names')",
-    NULL,
-    expect_identical_linter()
-  )
+  expect_no_lint("expect_equal(x, y, ignore_attr = 'names')", expect_identical_linter())
 })
 
 # this arose where a helper function was wrapping expect_equal() and
 #   some of the "allowed" arguments were being passed --> false positive
 test_that("expect_identical_linter skips calls using ...", {
-  expect_lint("expect_equal(x, y, ...)", NULL, expect_identical_linter())
+  expect_no_lint("expect_equal(x, y, ...)", expect_identical_linter())
 })
 
 test_that("fix works", {

--- a/tests/testthat/test-expect_length.R
+++ b/tests/testthat/test-expect_length.R
@@ -1,27 +1,19 @@
 test_that("expect_length_linter skips allowed usages", {
   linter <- expect_length_linter()
 
-  expect_lint("expect_equal(nrow(x), 4L)", NULL, linter)
+  expect_no_lint("expect_equal(nrow(x), 4L)", linter)
   # NB: also applies to tinytest, but it's sufficient to test testthat
-  expect_lint("expect_equal(nrow(x), 4L)", NULL, linter)
+  expect_no_lint("expect_equal(nrow(x), 4L)", linter)
 
   # only check the first argument. yoda tests in the second argument will be
   #   missed, but there are legitimate uses of length() in argument 2
   # expect_lint("expect_equal(nrow(x), length(y))", NULL, linter)
 
   # expect_length() doesn't have info= or label= arguments
-  expect_lint(
-    "expect_equal(length(x), n, info = 'x should have size n')",
-    NULL,
-    linter
-  )
-  expect_lint("expect_equal(length(x), n, label = 'x size')", NULL, linter)
-  expect_lint("expect_equal(length(x), length(y))", NULL, linter)
-  expect_lint(
-    "expect_equal(length(x), n, expected.label = 'target size')",
-    NULL,
-    linter
-  )
+  expect_no_lint("expect_equal(length(x), n, info = 'x should have size n')", linter)
+  expect_no_lint("expect_equal(length(x), n, label = 'x size')", linter)
+  expect_no_lint("expect_equal(length(x), length(y))", linter)
+  expect_no_lint("expect_equal(length(x), n, expected.label = 'target size')", linter)
 })
 
 test_that("expect_length_linter blocks simple disallowed usages", {

--- a/tests/testthat/test-expect_length.R
+++ b/tests/testthat/test-expect_length.R
@@ -10,10 +10,16 @@ test_that("expect_length_linter skips allowed usages", {
   # expect_lint("expect_equal(nrow(x), length(y))", NULL, linter)
 
   # expect_length() doesn't have info= or label= arguments
-  expect_no_lint("expect_equal(length(x), n, info = 'x should have size n')", linter)
+  expect_no_lint(
+    "expect_equal(length(x), n, info = 'x should have size n')",
+    linter
+  )
   expect_no_lint("expect_equal(length(x), n, label = 'x size')", linter)
   expect_no_lint("expect_equal(length(x), length(y))", linter)
-  expect_no_lint("expect_equal(length(x), n, expected.label = 'target size')", linter)
+  expect_no_lint(
+    "expect_equal(length(x), n, expected.label = 'target size')",
+    linter
+  )
 })
 
 test_that("expect_length_linter blocks simple disallowed usages", {

--- a/tests/testthat/test-expect_named.R
+++ b/tests/testthat/test-expect_named.R
@@ -2,28 +2,28 @@ test_that("expect_named_linter skips allowed usages", {
   linter <- expect_named_linter()
 
   # colnames(), rownames(), and dimnames() tests are not equivalent
-  expect_lint("expect_equal(colnames(x), 'a')", NULL, linter)
-  expect_lint("expect_equal(rownames(x), 'a')", NULL, linter)
-  expect_lint("expect_equal(dimnames(x), 'a')", NULL, linter)
+  expect_no_lint("expect_equal(colnames(x), 'a')", linter)
+  expect_no_lint("expect_equal(rownames(x), 'a')", linter)
+  expect_no_lint("expect_equal(dimnames(x), 'a')", linter)
 
-  expect_lint("expect_equal(nrow(x), 4L)", NULL, linter)
+  expect_no_lint("expect_equal(nrow(x), 4L)", linter)
   # NB: also applies to tinytest, but it's sufficient to test testthat
-  expect_lint("testthat::expect_equal(nrow(x), 4L)", NULL, linter)
+  expect_no_lint("testthat::expect_equal(nrow(x), 4L)", linter)
 
   # only check the first argument. yoda tests in the second argument will be
   #   missed, but there are legitimate uses of names() in argument 2
-  expect_lint("expect_equal(colnames(x), names(y))", NULL, linter)
+  expect_no_lint("expect_equal(colnames(x), names(y))", linter)
 
   # more readable than expect_named(x, names(y))
-  expect_lint("expect_equal(names(x), names(y))", NULL, linter)
+  expect_no_lint("expect_equal(names(x), names(y))", linter)
 })
 
 test_that("expect_equal(names(x), NULL) lints with expect_null, not expect_named", {
   linter_named <- expect_named_linter()
   linter_null <- expect_null_linter()
 
-  expect_lint("expect_equal(names(xs), NULL)", NULL, linter_named)
-  expect_lint("expect_identical(names(xs), NULL)", NULL, linter_named)
+  expect_no_lint("expect_equal(names(xs), NULL)", linter_named)
+  expect_no_lint("expect_identical(names(xs), NULL)", linter_named)
 
   expect_lint(
     "expect_equal(names(xs), NULL)",

--- a/tests/testthat/test-expect_not.R
+++ b/tests/testthat/test-expect_not.R
@@ -1,17 +1,17 @@
 test_that("expect_not_linter skips allowed usages", {
-  expect_lint("expect_true(x)", NULL, expect_not_linter())
-  expect_lint("expect_false(x)", NULL, expect_not_linter())
+  expect_no_lint("expect_true(x)", expect_not_linter())
+  expect_no_lint("expect_false(x)", expect_not_linter())
 
   # not a strict ban on !
   ##  (expect_false(x && y) is the same, but it's not clear which to prefer)
-  expect_lint("expect_true(!x || !y)", NULL, expect_not_linter())
+  expect_no_lint("expect_true(!x || !y)", expect_not_linter())
 })
 
 test_that("expect_not_linter doesn't block rlang bang-bang", {
-  expect_lint("expect_true(!!x)", NULL, expect_not_linter())
-  expect_lint("expect_true(!!!x)", NULL, expect_not_linter())
-  expect_lint("expect_false(!!x)", NULL, expect_not_linter())
-  expect_lint("expect_false(!!!x)", NULL, expect_not_linter())
+  expect_no_lint("expect_true(!!x)", expect_not_linter())
+  expect_no_lint("expect_true(!!!x)", expect_not_linter())
+  expect_no_lint("expect_false(!!x)", expect_not_linter())
+  expect_no_lint("expect_false(!!!x)", expect_not_linter())
 })
 
 test_that("expect_not_linter blocks simple disallowed usages", {

--- a/tests/testthat/test-expect_null.R
+++ b/tests/testthat/test-expect_null.R
@@ -3,15 +3,15 @@ test_that("expect_null_linter skips allowed usages", {
 
   # NB: this usage should be expect_false(), but this linter should
   #   nevertheless apply (e.g. for maintainers not using expect_not_linter)
-  expect_lint("expect_true(!is.null(x))", NULL, linter)
+  expect_no_lint("expect_true(!is.null(x))", linter)
   # NB: also applies to tinytest, but it's sufficient to test testthat
-  expect_lint("testthat::expect_true(!is.null(x))", NULL, linter)
+  expect_no_lint("testthat::expect_true(!is.null(x))", linter)
 
   # length-0 could be NULL, but could be integer() or list(), so let it pass
-  expect_lint("expect_length(x, 0L)", NULL, linter)
+  expect_no_lint("expect_length(x, 0L)", linter)
 
   # no false positive for is.null() at the wrong positional argument
-  expect_lint("expect_true(x, is.null(y))", NULL, linter)
+  expect_no_lint("expect_true(x, is.null(y))", linter)
 })
 
 test_that("expect_null_linter blocks simple disallowed usages", {

--- a/tests/testthat/test-expect_true_false.R
+++ b/tests/testthat/test-expect_true_false.R
@@ -1,10 +1,6 @@
 test_that("expect_true_false_linter skips allowed usages", {
   # expect_true is a scalar test; testing logical vectors with expect_equal is OK
-  expect_lint(
-    "expect_equal(x, c(TRUE, FALSE))",
-    NULL,
-    expect_true_false_linter()
-  )
+  expect_no_lint("expect_equal(x, c(TRUE, FALSE))", expect_true_false_linter())
 })
 
 test_that("expect_true_false_linter blocks simple disallowed usages", {

--- a/tests/testthat/test-expect_type.R
+++ b/tests/testthat/test-expect_type.R
@@ -13,10 +13,16 @@ test_that("expect_type_linter skips allowed usages", {
   expect_no_lint("expect_true(typeof(x) %in% c('builtin', 'closure'))", linter)
 
   # expect_type() doesn't have info= or label= arguments
-  expect_no_lint("expect_equal(typeof(x), t, info = 'x should have type t')", linter)
+  expect_no_lint(
+    "expect_equal(typeof(x), t, info = 'x should have type t')",
+    linter
+  )
   expect_no_lint("expect_equal(typeof(x), t, label = 'x type')", linter)
   expect_no_lint("expect_equal(typeof(x), t, expected.label = 'type')", linter)
-  expect_no_lint("expect_true(is.double(x), info = 'x should be double')", linter)
+  expect_no_lint(
+    "expect_true(is.double(x), info = 'x should be double')",
+    linter
+  )
 })
 
 test_that("expect_type_linter blocks simple disallowed usages", {

--- a/tests/testthat/test-expect_type.R
+++ b/tests/testthat/test-expect_type.R
@@ -2,37 +2,21 @@ test_that("expect_type_linter skips allowed usages", {
   linter <- expect_type_linter()
 
   # expect_type doesn't have an inverted version
-  expect_lint("expect_true(!is.numeric(x))", NULL, linter)
+  expect_no_lint("expect_true(!is.numeric(x))", linter)
   # NB: also applies to tinytest, but it's sufficient to test testthat
-  expect_lint("testthat::expect_true(!is.numeric(x))", NULL, linter)
+  expect_no_lint("testthat::expect_true(!is.numeric(x))", linter)
 
   # other is.<x> calls are not suitable for expect_type in particular
-  expect_lint("expect_true(is.data.frame(x))", NULL, linter)
+  expect_no_lint("expect_true(is.data.frame(x))", linter)
 
   # expect_type(x, ...) cannot be cleanly used here:
-  expect_lint(
-    "expect_true(typeof(x) %in% c('builtin', 'closure'))",
-    NULL,
-    linter
-  )
+  expect_no_lint("expect_true(typeof(x) %in% c('builtin', 'closure'))", linter)
 
   # expect_type() doesn't have info= or label= arguments
-  expect_lint(
-    "expect_equal(typeof(x), t, info = 'x should have type t')",
-    NULL,
-    linter
-  )
-  expect_lint("expect_equal(typeof(x), t, label = 'x type')", NULL, linter)
-  expect_lint(
-    "expect_equal(typeof(x), t, expected.label = 'type')",
-    NULL,
-    linter
-  )
-  expect_lint(
-    "expect_true(is.double(x), info = 'x should be double')",
-    NULL,
-    linter
-  )
+  expect_no_lint("expect_equal(typeof(x), t, info = 'x should have type t')", linter)
+  expect_no_lint("expect_equal(typeof(x), t, label = 'x type')", linter)
+  expect_no_lint("expect_equal(typeof(x), t, expected.label = 'type')", linter)
+  expect_no_lint("expect_true(is.double(x), info = 'x should be double')", linter)
 })
 
 test_that("expect_type_linter blocks simple disallowed usages", {

--- a/tests/testthat/test-flint_ignore.R
+++ b/tests/testthat/test-flint_ignore.R
@@ -1,14 +1,10 @@
 test_that("flir-ignore works for a single line", {
-  expect_lint("# flir-ignore\nany(duplicated(x))", NULL, NULL)
+  expect_no_lint("# flir-ignore\nany(duplicated(x))", NULL)
   expect_fix("# flir-ignore\nany(duplicated(x))", character(0))
 })
 
 test_that("flir-ignore: specific rules work", {
-  expect_lint(
-    "# flir-ignore: any_duplicated-1\nany(duplicated(x))",
-    NULL,
-    NULL
-  )
+  expect_no_lint("# flir-ignore: any_duplicated-1\nany(duplicated(x))", NULL)
   expect_fix(
     "# flir-ignore: any_duplicated-1\nany(duplicated(x))",
     character(0)
@@ -39,11 +35,7 @@ test_that("flir-ignore doesn't ignore more than one line", {
 })
 
 test_that("flir-ignore-start and end work", {
-  expect_lint(
-    "# flir-ignore-start\nany(duplicated(x))\nany(duplicated(y))\n# flir-ignore-end",
-    NULL,
-    NULL
-  )
+  expect_no_lint("# flir-ignore-start\nany(duplicated(x))\nany(duplicated(y))\n# flir-ignore-end", NULL)
   expect_fix(
     "# flir-ignore-start\nany(duplicated(x))\nany(duplicated(y))\n# flir-ignore-end",
     character(0)
@@ -51,11 +43,7 @@ test_that("flir-ignore-start and end work", {
 })
 
 test_that("flir-ignore-start and end work with specific rule", {
-  expect_lint(
-    "# flir-ignore-start: any_duplicated-1\nany(duplicated(x))\nany(duplicated(y))\n# flir-ignore-end",
-    NULL,
-    NULL
-  )
+  expect_no_lint("# flir-ignore-start: any_duplicated-1\nany(duplicated(x))\nany(duplicated(y))\n# flir-ignore-end", NULL)
   expect_fix(
     "# flir-ignore-start: any_duplicated-1\nany(duplicated(x))\nany(duplicated(y))\n# flir-ignore-end",
     character(0)

--- a/tests/testthat/test-flint_ignore.R
+++ b/tests/testthat/test-flint_ignore.R
@@ -35,7 +35,10 @@ test_that("flir-ignore doesn't ignore more than one line", {
 })
 
 test_that("flir-ignore-start and end work", {
-  expect_no_lint("# flir-ignore-start\nany(duplicated(x))\nany(duplicated(y))\n# flir-ignore-end", NULL)
+  expect_no_lint(
+    "# flir-ignore-start\nany(duplicated(x))\nany(duplicated(y))\n# flir-ignore-end",
+    NULL
+  )
   expect_fix(
     "# flir-ignore-start\nany(duplicated(x))\nany(duplicated(y))\n# flir-ignore-end",
     character(0)
@@ -43,7 +46,10 @@ test_that("flir-ignore-start and end work", {
 })
 
 test_that("flir-ignore-start and end work with specific rule", {
-  expect_no_lint("# flir-ignore-start: any_duplicated-1\nany(duplicated(x))\nany(duplicated(y))\n# flir-ignore-end", NULL)
+  expect_no_lint(
+    "# flir-ignore-start: any_duplicated-1\nany(duplicated(x))\nany(duplicated(y))\n# flir-ignore-end",
+    NULL
+  )
   expect_fix(
     "# flir-ignore-start: any_duplicated-1\nany(duplicated(x))\nany(duplicated(y))\n# flir-ignore-end",
     character(0)

--- a/tests/testthat/test-for_loop_index.R
+++ b/tests/testthat/test-for_loop_index.R
@@ -1,16 +1,15 @@
 test_that("for_loop_index_linter skips allowed usages", {
   linter <- for_loop_index_linter()
 
-  expect_lint("for (xi in x) {}", NULL, linter)
+  expect_no_lint("for (xi in x) {}", linter)
 
   # this is OK, so not every symbol is problematic
-  expect_lint("for (col in DF$col) {}", NULL, linter)
-  expect_lint("for (col in S4@col) {}", NULL, linter)
-  expect_lint("for (col in DT[, col]) {}", NULL, linter)
+  expect_no_lint("for (col in DF$col) {}", linter)
+  expect_no_lint("for (col in S4@col) {}", linter)
+  expect_no_lint("for (col in DT[, col]) {}", linter)
 
   # make sure symbol check is scoped
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       {
         for (i in 1:10) {
@@ -19,10 +18,7 @@ test_that("for_loop_index_linter skips allowed usages", {
         i <- 7L
       }
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 })
 
 test_that("for_loop_index_linter blocks simple disallowed usages", {
@@ -32,8 +28,8 @@ test_that("for_loop_index_linter blocks simple disallowed usages", {
   expect_lint("for (x in x) {}", lint_msg, linter)
   # these also overwrite a variable in calling scope
   expect_lint("for (x in foo(x)) {}", lint_msg, linter)
-  expect_lint("for (x in foo(x = 1)) {}", NULL, linter)
+  expect_no_lint("for (x in foo(x = 1)) {}", linter)
   # arbitrary nesting
   expect_lint("for (x in foo(bar(y, baz(2, x)))) {}", lint_msg, linter)
-  expect_lint("for (x in foo(bar(y, baz(2, x = z)))) {}", NULL, linter)
+  expect_no_lint("for (x in foo(bar(y, baz(2, x = z)))) {}", linter)
 })

--- a/tests/testthat/test-for_loop_index.R
+++ b/tests/testthat/test-for_loop_index.R
@@ -9,7 +9,8 @@ test_that("for_loop_index_linter skips allowed usages", {
   expect_no_lint("for (col in DT[, col]) {}", linter)
 
   # make sure symbol check is scoped
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       {
         for (i in 1:10) {
@@ -18,7 +19,9 @@ test_that("for_loop_index_linter skips allowed usages", {
         i <- 7L
       }
     "
-    ), linter)
+    ),
+    linter
+  )
 })
 
 test_that("for_loop_index_linter blocks simple disallowed usages", {

--- a/tests/testthat/test-function_return.R
+++ b/tests/testthat/test-function_return.R
@@ -7,7 +7,7 @@ test_that("function_return_linter skips allowed usages", {
     }
   "
   )
-  expect_lint(lines_simple, NULL, function_return_linter())
+  expect_no_lint(lines_simple, function_return_linter())
 
   # arguably an expression as complicated as this should also be assigned,
   #   but for now that's out of the scope of this linter
@@ -21,7 +21,7 @@ test_that("function_return_linter skips allowed usages", {
     }
   "
   )
-  expect_lint(lines_subassignment, NULL, function_return_linter())
+  expect_no_lint(lines_subassignment, function_return_linter())
 })
 
 test_that("function_return_linter blocks simple disallowed usages", {

--- a/tests/testthat/test-implicit_assignment.R
+++ b/tests/testthat/test-implicit_assignment.R
@@ -11,59 +11,81 @@ test_that("implicit_assignment_linter skips allowed usages", {
   expect_no_lint("abc <- mean(1:4)", linter)
   expect_no_lint("mean(1:4) -> abc", linter)
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
     x <- 1:4
     mean(x)"
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
     x <- 1L
     if (x) TRUE"
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
     0L -> abc
     while (abc) {
       FALSE
     }"
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
     if (x > 20L) {
       x <- x / 2.0
     }"
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
     i <- 1
     while (i < 6L) {
       print(i)
       i <- i + 1
     }"
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
     foo <- function(x) {
       x <- x + 1
       return(x)
     }"
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
     f <- function() {
       p <- g()
       p <- if (is.null(p)) x else p
     }"
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       map(
         .x = 1:4,
@@ -72,24 +94,32 @@ test_that("implicit_assignment_linter skips allowed usages", {
           x
         }
       )"
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       lapply(1:4, function(x) {
         x <- x + 1
         x
       })"
-    ), linter)
+    ),
+    linter
+  )
 
   skip_if_not_r_version("4.1.0")
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       map(1:4, \\(x) {
         x <- x + 1
         x
       })"
-    ), linter)
+    ),
+    linter
+  )
 })
 
 # test_that("implicit_assignment_linter respects except argument", {
@@ -127,60 +157,81 @@ test_that("implicit_assignment_linter skips allowed usages", {
 test_that("implicit_assignment_linter skips allowed usages with braces", {
   linter <- implicit_assignment_linter()
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
     foo({
       a <- 1L
     })
     "
-    ), linter)
-  expect_no_lint(trim_some(
+    ),
+    linter
+  )
+  expect_no_lint(
+    trim_some(
       "
     output <- capture.output({
       x <- f()
     })
     "
-    ), linter)
-  expect_no_lint(trim_some(
+    ),
+    linter
+  )
+  expect_no_lint(
+    trim_some(
       "
     quote({
       a <- 1L
     })
     "
-    ), linter)
-  expect_no_lint(trim_some(
+    ),
+    linter
+  )
+  expect_no_lint(
+    trim_some(
       "
     bquote({
       a <- 1L
     })
     "
-    ), linter)
-  expect_no_lint(trim_some(
+    ),
+    linter
+  )
+  expect_no_lint(
+    trim_some(
       "
     expression({
       a <- 1L
     })
     "
-    ), linter)
-  expect_no_lint(trim_some(
+    ),
+    linter
+  )
+  expect_no_lint(
+    trim_some(
       "
     local({
       a <- 1L
     })
     "
-    ), linter)
+    ),
+    linter
+  )
 })
 
 test_that("implicit_assignment_linter makes exceptions for functions that capture side-effects", {
   linter <- implicit_assignment_linter()
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
     test_that('my test', {
       a <- 1L
       expect_equal(a, 1L)
     })"
-    ), linter)
+    ),
+    linter
+  )
 
   # rlang
   expect_no_lint("expr(a <- 1L)", linter)

--- a/tests/testthat/test-implicit_assignment.R
+++ b/tests/testthat/test-implicit_assignment.R
@@ -1,98 +1,69 @@
 test_that("implicit_assignment_linter skips allowed usages", {
   linter <- implicit_assignment_linter()
 
-  expect_lint("x <- 1L", NULL, linter)
-  expect_lint("1L -> x", NULL, linter)
-  expect_lint("x <<- 1L", NULL, linter)
-  expect_lint("1L ->> x", NULL, linter)
-  expect_lint("y <- if (is.null(x)) z else x", NULL, linter)
-  expect_lint("for (x in 1:10) x <- x + 1", NULL, linter)
+  expect_no_lint("x <- 1L", linter)
+  expect_no_lint("1L -> x", linter)
+  expect_no_lint("x <<- 1L", linter)
+  expect_no_lint("1L ->> x", linter)
+  expect_no_lint("y <- if (is.null(x)) z else x", linter)
+  expect_no_lint("for (x in 1:10) x <- x + 1", linter)
 
-  expect_lint("abc <- mean(1:4)", NULL, linter)
-  expect_lint("mean(1:4) -> abc", NULL, linter)
+  expect_no_lint("abc <- mean(1:4)", linter)
+  expect_no_lint("mean(1:4) -> abc", linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
     x <- 1:4
     mean(x)"
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
     x <- 1L
     if (x) TRUE"
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
     0L -> abc
     while (abc) {
       FALSE
     }"
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
     if (x > 20L) {
       x <- x / 2.0
     }"
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
     i <- 1
     while (i < 6L) {
       print(i)
       i <- i + 1
     }"
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
     foo <- function(x) {
       x <- x + 1
       return(x)
     }"
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
     f <- function() {
       p <- g()
       p <- if (is.null(p)) x else p
     }"
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       map(
         .x = 1:4,
@@ -101,35 +72,24 @@ test_that("implicit_assignment_linter skips allowed usages", {
           x
         }
       )"
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       lapply(1:4, function(x) {
         x <- x + 1
         x
       })"
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
   skip_if_not_r_version("4.1.0")
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       map(1:4, \\(x) {
         x <- x + 1
         x
       })"
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 })
 
 # test_that("implicit_assignment_linter respects except argument", {
@@ -167,93 +127,65 @@ test_that("implicit_assignment_linter skips allowed usages", {
 test_that("implicit_assignment_linter skips allowed usages with braces", {
   linter <- implicit_assignment_linter()
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
     foo({
       a <- 1L
     })
     "
-    ),
-    NULL,
-    linter
-  )
-  expect_lint(
-    trim_some(
+    ), linter)
+  expect_no_lint(trim_some(
       "
     output <- capture.output({
       x <- f()
     })
     "
-    ),
-    NULL,
-    linter
-  )
-  expect_lint(
-    trim_some(
+    ), linter)
+  expect_no_lint(trim_some(
       "
     quote({
       a <- 1L
     })
     "
-    ),
-    NULL,
-    linter
-  )
-  expect_lint(
-    trim_some(
+    ), linter)
+  expect_no_lint(trim_some(
       "
     bquote({
       a <- 1L
     })
     "
-    ),
-    NULL,
-    linter
-  )
-  expect_lint(
-    trim_some(
+    ), linter)
+  expect_no_lint(trim_some(
       "
     expression({
       a <- 1L
     })
     "
-    ),
-    NULL,
-    linter
-  )
-  expect_lint(
-    trim_some(
+    ), linter)
+  expect_no_lint(trim_some(
       "
     local({
       a <- 1L
     })
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 })
 
 test_that("implicit_assignment_linter makes exceptions for functions that capture side-effects", {
   linter <- implicit_assignment_linter()
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
     test_that('my test', {
       a <- 1L
       expect_equal(a, 1L)
     })"
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
   # rlang
-  expect_lint("expr(a <- 1L)", NULL, linter)
-  expect_lint("quo(a <- 1L)", NULL, linter)
-  expect_lint("quos(a <- 1L)", NULL, linter)
+  expect_no_lint("expr(a <- 1L)", linter)
+  expect_no_lint("quo(a <- 1L)", linter)
+  expect_no_lint("quos(a <- 1L)", linter)
 })
 
 test_that("implicit_assignment_linter blocks disallowed usages in simple conditional statements", {
@@ -374,15 +306,15 @@ test_that("implicit_assignment_linter blocks disallowed usages in nested conditi
 test_that("implicit_assignment_linter works as expected with pipes and walrus operator", {
   linter <- implicit_assignment_linter()
 
-  expect_lint("data %>% mutate(a := b)", NULL, linter)
-  expect_lint("dt %>% .[, z := x + y]", NULL, linter)
-  expect_lint("data %<>% mutate(a := b)", NULL, linter)
+  expect_no_lint("data %>% mutate(a := b)", linter)
+  expect_no_lint("dt %>% .[, z := x + y]", linter)
+  expect_no_lint("data %<>% mutate(a := b)", linter)
 
-  expect_lint("DT[i, x := i]", NULL, linter)
+  expect_no_lint("DT[i, x := i]", linter)
 
   skip_if_not_r_version("4.1.0")
 
-  expect_lint("data |> mutate(a := b)", NULL, linter)
+  expect_no_lint("data |> mutate(a := b)", linter)
 })
 
 test_that("parenthetical assignments are caught", {

--- a/tests/testthat/test-is_numeric.R
+++ b/tests/testthat/test-is_numeric.R
@@ -1,21 +1,21 @@
 test_that("is_numeric_linter skips allowed usages involving ||", {
   linter <- is_numeric_linter()
 
-  expect_lint("is.numeric(x) || is.integer(y)", NULL, linter)
+  expect_no_lint("is.numeric(x) || is.integer(y)", linter)
   # x is used, but not identically
-  expect_lint("is.numeric(x) || is.integer(foo(x))", NULL, linter)
+  expect_no_lint("is.numeric(x) || is.integer(foo(x))", linter)
   # not totally crazy, e.g. if input accepts a vector or a list
-  expect_lint("is.numeric(x) || is.integer(x[[1]])", NULL, linter)
+  expect_no_lint("is.numeric(x) || is.integer(x[[1]])", linter)
 })
 
 test_that("is_numeric_linter skips allowed usages involving %in%", {
   linter <- is_numeric_linter()
 
   # false positives for class(x) %in% c('integer', 'numeric') style
-  expect_lint("class(x) %in% 1:10", NULL, linter)
-  expect_lint("class(x) %in% 'numeric'", NULL, linter)
-  expect_lint("class(x) %in% c('numeric', 'integer', 'factor')", NULL, linter)
-  expect_lint("class(x) %in% c('numeric', 'integer', y)", NULL, linter)
+  expect_no_lint("class(x) %in% 1:10", linter)
+  expect_no_lint("class(x) %in% 'numeric'", linter)
+  expect_no_lint("class(x) %in% c('numeric', 'integer', 'factor')", linter)
+  expect_no_lint("class(x) %in% c('numeric', 'integer', y)", linter)
 })
 
 test_that("is_numeric_linter blocks disallowed usages involving ||", {
@@ -69,12 +69,8 @@ test_that("raw strings are handled properly when testing in class", {
   linter <- is_numeric_linter()
   lint_msg <- "can be simplified to is.numeric"
 
-  expect_lint(
-    "class(x) %in% c(R'(numeric)', 'integer', 'factor')",
-    NULL,
-    linter
-  )
-  expect_lint("class(x) %in% c('numeric', R'--(integer)--', y)", NULL, linter)
+  expect_no_lint("class(x) %in% c(R'(numeric)', 'integer', 'factor')", linter)
+  expect_no_lint("class(x) %in% c('numeric', R'--(integer)--', y)", linter)
 
   # TODO: fix that
   # expect_lint("class(x) %in% c(R'(integer)', 'numeric')", lint_msg, linter)

--- a/tests/testthat/test-length_levels.R
+++ b/tests/testthat/test-length_levels.R
@@ -1,5 +1,5 @@
 test_that("length_levels_linter skips allowed usages", {
-  expect_lint("length(c(levels(x), 'a'))", NULL, length_levels_linter())
+  expect_no_lint("length(c(levels(x), 'a'))", length_levels_linter())
 })
 
 test_that("length_levels_linter blocks simple disallowed usages", {

--- a/tests/testthat/test-length_test.R
+++ b/tests/testthat/test-length_test.R
@@ -1,8 +1,8 @@
 test_that("skips allowed usages", {
   linter <- length_test_linter()
 
-  expect_lint("length(x) > 0", NULL, linter)
-  expect_lint("length(DF[key == val, cols])", NULL, linter)
+  expect_no_lint("length(x) > 0", linter)
+  expect_no_lint("length(DF[key == val, cols])", linter)
 })
 
 test_that("blocks simple disallowed usages", {

--- a/tests/testthat/test-lengths.R
+++ b/tests/testthat/test-lengths.R
@@ -1,12 +1,12 @@
 test_that("NULL skips allowed usages", {
   linter <- lengths_linter()
 
-  expect_lint("length(x)", NULL, linter)
-  expect_lint("function(x) length(x) + 1L", NULL, linter)
-  expect_lint("vapply(x, fun, integer(length(y)))", NULL, linter)
-  expect_lint("sapply(x, sqrt, simplify = length(x))", NULL, linter)
-  expect_lint("lapply(x, length)", NULL, linter)
-  expect_lint("map(x, length)", NULL, linter)
+  expect_no_lint("length(x)", linter)
+  expect_no_lint("function(x) length(x) + 1L", linter)
+  expect_no_lint("vapply(x, fun, integer(length(y)))", linter)
+  expect_no_lint("sapply(x, sqrt, simplify = length(x))", linter)
+  expect_no_lint("lapply(x, length)", linter)
+  expect_no_lint("map(x, length)", linter)
 })
 
 test_that("NULL blocks simple disallowed base usages", {

--- a/tests/testthat/test-library_call.R
+++ b/tests/testthat/test-library_call.R
@@ -1,37 +1,49 @@
 test_that("library_call_linter skips allowed usages", {
   linter <- library_call_linter()
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       library(dplyr)
       print('test')
     "
-    ), linter)
+    ),
+    linter
+  )
 
   expect_no_lint("print('test')", linter)
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       # comment
       library(dplyr)
     "
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       print('test')
       # library(dplyr)
     "
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       suppressPackageStartupMessages({
         library(dplyr)
         library(knitr)
       })
     "
-    ), linter)
+    ),
+    linter
+  )
 })
 
 test_that("library_call_linter warns on disallowed usages", {
@@ -95,12 +107,15 @@ test_that("require() treated the same as library()", {
   lint_message_library <- "Move all library/require calls to the top of the script."
   lint_message_require <- "Move all require calls to the top of the script."
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       library(dplyr)
       require(tidyr)
     "
-    ), linter)
+    ),
+    linter
+  )
 
   expect_lint(
     trim_some(
@@ -133,7 +148,10 @@ test_that("skips allowed usages of library()/character.only=TRUE", {
 
   expect_no_lint("library(data.table)", linter)
   expect_no_lint("function(pkg) library(pkg, character.only = TRUE)", linter)
-  expect_no_lint("function(pkgs) sapply(pkgs, require, character.only = TRUE)", linter)
+  expect_no_lint(
+    "function(pkgs) sapply(pkgs, require, character.only = TRUE)",
+    linter
+  )
 })
 
 patrick::with_parameters_test_that(
@@ -148,7 +166,8 @@ patrick::with_parameters_test_that(
     expect_no_lint(sprintf("%1$s(x); y; %1$s(z)", call), linter)
 
     # inline or potentially with gaps don't matter
-    expect_no_lint(trim_some(
+    expect_no_lint(
+      trim_some(
         glue::glue(
           "
         {call}(x)
@@ -157,17 +176,22 @@ patrick::with_parameters_test_that(
         stopifnot(z)
       "
         )
-      ), linter)
+      ),
+      linter
+    )
 
     # only suppressing calls with library()
-    expect_no_lint(trim_some(
+    expect_no_lint(
+      trim_some(
         glue::glue(
           "
         {call}(x)
         {call}(y)
       "
         )
-      ), linter)
+      ),
+      linter
+    )
   },
   .test_name = c("suppressMessages", "suppressPackageStartupMessages"),
   call = c("suppressMessages", "suppressPackageStartupMessages")
@@ -234,5 +258,8 @@ patrick::with_parameters_test_that(
 # })
 
 test_that("Consecutive calls to different blocked calls is OK", {
-  expect_no_lint("suppressPackageStartupMessages(library(x)); suppressMessages(library(y))", library_call_linter())
+  expect_no_lint(
+    "suppressPackageStartupMessages(library(x)); suppressMessages(library(y))",
+    library_call_linter()
+  )
 })

--- a/tests/testthat/test-library_call.R
+++ b/tests/testthat/test-library_call.R
@@ -1,57 +1,37 @@
 test_that("library_call_linter skips allowed usages", {
   linter <- library_call_linter()
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       library(dplyr)
       print('test')
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    "print('test')",
-    NULL,
-    linter
-  )
+  expect_no_lint("print('test')", linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       # comment
       library(dplyr)
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       print('test')
       # library(dplyr)
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       suppressPackageStartupMessages({
         library(dplyr)
         library(knitr)
       })
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 })
 
 test_that("library_call_linter warns on disallowed usages", {
@@ -115,16 +95,12 @@ test_that("require() treated the same as library()", {
   lint_message_library <- "Move all library/require calls to the top of the script."
   lint_message_require <- "Move all require calls to the top of the script."
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       library(dplyr)
       require(tidyr)
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
   expect_lint(
     trim_some(
@@ -155,13 +131,9 @@ test_that("require() treated the same as library()", {
 test_that("skips allowed usages of library()/character.only=TRUE", {
   linter <- library_call_linter()
 
-  expect_lint("library(data.table)", NULL, linter)
-  expect_lint("function(pkg) library(pkg, character.only = TRUE)", NULL, linter)
-  expect_lint(
-    "function(pkgs) sapply(pkgs, require, character.only = TRUE)",
-    NULL,
-    linter
-  )
+  expect_no_lint("library(data.table)", linter)
+  expect_no_lint("function(pkg) library(pkg, character.only = TRUE)", linter)
+  expect_no_lint("function(pkgs) sapply(pkgs, require, character.only = TRUE)", linter)
 })
 
 patrick::with_parameters_test_that(
@@ -169,15 +141,14 @@ patrick::with_parameters_test_that(
   {
     linter <- library_call_linter()
 
-    expect_lint(sprintf("%s(x)", call), NULL, linter)
-    expect_lint(sprintf("%s(x, y, z)", call), NULL, linter)
+    expect_no_lint(sprintf("%s(x)", call), linter)
+    expect_no_lint(sprintf("%s(x, y, z)", call), linter)
 
     # intervening expression
-    expect_lint(sprintf("%1$s(x); y; %1$s(z)", call), NULL, linter)
+    expect_no_lint(sprintf("%1$s(x); y; %1$s(z)", call), linter)
 
     # inline or potentially with gaps don't matter
-    expect_lint(
-      trim_some(
+    expect_no_lint(trim_some(
         glue::glue(
           "
         {call}(x)
@@ -186,24 +157,17 @@ patrick::with_parameters_test_that(
         stopifnot(z)
       "
         )
-      ),
-      NULL,
-      linter
-    )
+      ), linter)
 
     # only suppressing calls with library()
-    expect_lint(
-      trim_some(
+    expect_no_lint(trim_some(
         glue::glue(
           "
         {call}(x)
         {call}(y)
       "
         )
-      ),
-      NULL,
-      linter
-    )
+      ), linter)
   },
   .test_name = c("suppressMessages", "suppressPackageStartupMessages"),
   call = c("suppressMessages", "suppressPackageStartupMessages")
@@ -270,9 +234,5 @@ patrick::with_parameters_test_that(
 # })
 
 test_that("Consecutive calls to different blocked calls is OK", {
-  expect_lint(
-    "suppressPackageStartupMessages(library(x)); suppressMessages(library(y))",
-    NULL,
-    library_call_linter()
-  )
+  expect_no_lint("suppressPackageStartupMessages(library(x)); suppressMessages(library(y))", library_call_linter())
 })

--- a/tests/testthat/test-list_comparison.R
+++ b/tests/testthat/test-list_comparison.R
@@ -1,5 +1,5 @@
 test_that("list_comparison_linter skips allowed usages", {
-  expect_lint("sapply(x, sum) > 10", NULL, list_comparison_linter())
+  expect_no_lint("sapply(x, sum) > 10", list_comparison_linter())
 })
 
 local({

--- a/tests/testthat/test-literal_coercion.R
+++ b/tests/testthat/test-literal_coercion.R
@@ -2,42 +2,42 @@ test_that("literal_coercion_linter skips allowed usages", {
   linter <- literal_coercion_linter()
 
   # naive xpath includes the "_f0" here as a literal
-  expect_lint('as.numeric(x$"_f0")', NULL, linter)
-  expect_lint('as.numeric(x@"_f0")', NULL, linter)
+  expect_no_lint('as.numeric(x$"_f0")', linter)
+  expect_no_lint('as.numeric(x@"_f0")', linter)
   # only examine the first method for as.<type> methods
-  expect_lint("as.character(as.Date(x), '%Y%m%d')", NULL, linter)
+  expect_no_lint("as.character(as.Date(x), '%Y%m%d')", linter)
 
   # we are as yet agnostic on whether to prefer literals over coerced vectors
-  expect_lint("as.integer(c(1, 2, 3))", NULL, linter)
+  expect_no_lint("as.integer(c(1, 2, 3))", linter)
   # even more ambiguous for character vectors like here, where quotes are much
   #   more awkward to type than a sequence of numbers
-  expect_lint("as.character(c(1, 2, 3))", NULL, linter)
+  expect_no_lint("as.character(c(1, 2, 3))", linter)
   # not possible to declare raw literals
-  expect_lint("as.raw(c(1, 2, 3))", NULL, linter)
+  expect_no_lint("as.raw(c(1, 2, 3))", linter)
   # also not taking a stand on as.complex(0) vs. 0 + 0i
-  expect_lint("as.complex(0)", NULL, linter)
+  expect_no_lint("as.complex(0)", linter)
   # ditto for as.integer(1e6) vs. 1000000L
-  expect_lint("as.integer(1e6)", NULL, linter)
+  expect_no_lint("as.integer(1e6)", linter)
   # ditto for as.numeric(1:3) vs. c(1, 2, 3)
-  expect_lint("as.numeric(1:3)", NULL, linter)
+  expect_no_lint("as.numeric(1:3)", linter)
 })
 
 test_that("literal_coercion_linter skips allowed rlang usages", {
   linter <- literal_coercion_linter()
 
-  expect_lint("int(1, 2.0, 3)", NULL, linter)
-  expect_lint("chr('e', 'ab', 'xyz')", NULL, linter)
-  expect_lint("lgl(0, 1)", NULL, linter)
-  expect_lint("lgl(0L, 1)", NULL, linter)
-  expect_lint("dbl(1.2, 1e5, 3L, 2E4)", NULL, linter)
+  expect_no_lint("int(1, 2.0, 3)", linter)
+  expect_no_lint("chr('e', 'ab', 'xyz')", linter)
+  expect_no_lint("lgl(0, 1)", linter)
+  expect_no_lint("lgl(0L, 1)", linter)
+  expect_no_lint("dbl(1.2, 1e5, 3L, 2E4)", linter)
   # make sure using namespace (`rlang::`) doesn't create problems
-  expect_lint("rlang::int(1, 2, 3)", NULL, linter)
+  expect_no_lint("rlang::int(1, 2, 3)", linter)
   # even if scalar, carve out exceptions for the following
-  expect_lint("int(1.0e6)", NULL, linter)
+  expect_no_lint("int(1.0e6)", linter)
 })
 
 test_that("literal_coercion_linter skips quoted keyword arguments", {
-  expect_lint("as.numeric(foo('a' = 1))", NULL, literal_coercion_linter())
+  expect_no_lint("as.numeric(foo('a' = 1))", literal_coercion_linter())
 })
 
 skip_if_not_installed("patrick")

--- a/tests/testthat/test-matrix_apply.R
+++ b/tests/testthat/test-matrix_apply.R
@@ -1,31 +1,31 @@
 test_that("matrix_apply_linter skips allowed usages", {
   linter <- matrix_apply_linter()
 
-  expect_lint("apply(x, 1, prod)", NULL, linter)
+  expect_no_lint("apply(x, 1, prod)", linter)
 
-  expect_lint("apply(x, 1, function(i) sum(i[i > 0]))", NULL, linter)
+  expect_no_lint("apply(x, 1, function(i) sum(i[i > 0]))", linter)
 
   # sum as FUN argument
-  expect_lint("apply(x, 1, f, sum)", NULL, linter)
+  expect_no_lint("apply(x, 1, f, sum)", linter)
 
   # mean() with named arguments other than na.rm is skipped because they are not
   # implemented in colMeans() or rowMeans()
-  expect_lint("apply(x, 1, mean, trim = 0.2)", NULL, linter)
+  expect_no_lint("apply(x, 1, mean, trim = 0.2)", linter)
 })
 
 test_that("matrix_apply_linter is not implemented for complex MARGIN values", {
   linter <- matrix_apply_linter()
 
   # Could be implemented at some point
-  expect_lint("apply(x, seq(2, 4), sum)", NULL, linter)
+  expect_no_lint("apply(x, seq(2, 4), sum)", linter)
 
   # No equivalent
-  expect_lint("apply(x, c(2, 4), sum)", NULL, linter)
+  expect_no_lint("apply(x, c(2, 4), sum)", linter)
 
   # Beyond the scope of static analysis
-  expect_lint("apply(x, m, sum)", NULL, linter)
+  expect_no_lint("apply(x, m, sum)", linter)
 
-  expect_lint("apply(x, 1 + 2:4, sum)", NULL, linter)
+  expect_no_lint("apply(x, 1 + 2:4, sum)", linter)
 })
 
 test_that("matrix_apply_linter simple disallowed usages", {

--- a/tests/testthat/test-missing_argument.R
+++ b/tests/testthat/test-missing_argument.R
@@ -1,17 +1,17 @@
 test_that("missing_argument_linter skips allowed usages", {
   linter <- missing_argument_linter()
 
-  expect_lint("fun(x, a = 1)", NULL, linter)
-  expect_lint("fun(x = 1, a = 1)", NULL, linter)
-  expect_lint("dt[, 1]", NULL, linter)
-  expect_lint("dt[, 'col']", NULL, linter)
-  expect_lint("array[, , 1]", NULL, linter)
-  expect_lint("switch(a =, b =, c = 1, 0)", NULL, linter)
-  expect_lint("alist(a =, b =, c = 1, 0)", NULL, linter)
-  expect_lint("pairlist(path = quote(expr = ))", NULL, linter) # 1889
+  expect_no_lint("fun(x, a = 1)", linter)
+  expect_no_lint("fun(x = 1, a = 1)", linter)
+  expect_no_lint("dt[, 1]", linter)
+  expect_no_lint("dt[, 'col']", linter)
+  expect_no_lint("array[, , 1]", linter)
+  expect_no_lint("switch(a =, b =, c = 1, 0)", linter)
+  expect_no_lint("alist(a =, b =, c = 1, 0)", linter)
+  expect_no_lint("pairlist(path = quote(expr = ))", linter) # 1889
 
   # always allow this missing usage
-  expect_lint("foo()", NULL, linter)
+  expect_no_lint("foo()", linter)
 })
 
 test_that("missing_argument_linter blocks disallowed usages", {
@@ -89,8 +89,8 @@ test_that("missing_argument_linter blocks disallowed usages", {
 test_that("except list can be empty", {
   linter <- missing_argument_linter()
 
-  expect_lint("switch(a =, b = 1, 0)", NULL, linter)
-  expect_lint("alist(a =)", NULL, linter)
+  expect_no_lint("switch(a =, b = 1, 0)", linter)
+  expect_no_lint("alist(a =)", linter)
 })
 
 # test_that("allow_trailing can allow trailing empty args also for non-excepted functions", {

--- a/tests/testthat/test-nested_ifelse.R
+++ b/tests/testthat/test-nested_ifelse.R
@@ -1,14 +1,14 @@
 test_that("nested_ifelse_linter skips allowed usages", {
   linter <- nested_ifelse_linter()
 
-  expect_lint("if (TRUE) 1 else 2", NULL, linter)
-  expect_lint("if (TRUE) 1 else if (TRUE) 2 else 3", NULL, linter)
+  expect_no_lint("if (TRUE) 1 else 2", linter)
+  expect_no_lint("if (TRUE) 1 else if (TRUE) 2 else 3", linter)
 
-  expect_lint("ifelse(runif(10) > .2, 4, 6)", NULL, linter)
+  expect_no_lint("ifelse(runif(10) > .2, 4, 6)", linter)
 
   # don't block suggested alternatives
-  expect_lint("fcase(l1, v1, l2, v2)", NULL, linter)
-  expect_lint("case_when(l1 ~ v1, l2 ~ v2)", NULL, linter)
+  expect_no_lint("fcase(l1, v1, l2, v2)", linter)
+  expect_no_lint("case_when(l1 ~ v1, l2 ~ v2)", linter)
 })
 
 test_that("nested_ifelse_linter blocks simple disallowed usages", {

--- a/tests/testthat/test-numeric_leading_zero.R
+++ b/tests/testthat/test-numeric_leading_zero.R
@@ -1,17 +1,17 @@
 test_that("numeric_leading_zero_linter skips allowed usages", {
   linter <- numeric_leading_zero_linter()
 
-  expect_lint("a <- 0.1", NULL, linter)
-  expect_lint("b <- -0.2", NULL, linter)
-  expect_lint("c <- 3.0", NULL, linter)
-  expect_lint("d <- 4L", NULL, linter)
-  expect_lint("e <- TRUE", NULL, linter)
-  expect_lint("f <- 0.5e6", NULL, linter)
-  expect_lint("g <- 0x78", NULL, linter)
-  expect_lint("h <- 0.9 + 0.1i", NULL, linter)
-  expect_lint("h <- 0.9+0.1i", NULL, linter)
-  expect_lint("h <- 0.9 - 0.1i", NULL, linter)
-  expect_lint("i <- 2L + 3.4i", NULL, linter)
+  expect_no_lint("a <- 0.1", linter)
+  expect_no_lint("b <- -0.2", linter)
+  expect_no_lint("c <- 3.0", linter)
+  expect_no_lint("d <- 4L", linter)
+  expect_no_lint("e <- TRUE", linter)
+  expect_no_lint("f <- 0.5e6", linter)
+  expect_no_lint("g <- 0x78", linter)
+  expect_no_lint("h <- 0.9 + 0.1i", linter)
+  expect_no_lint("h <- 0.9+0.1i", linter)
+  expect_no_lint("h <- 0.9 - 0.1i", linter)
+  expect_no_lint("i <- 2L + 3.4i", linter)
 })
 
 test_that("numeric_leading_zero_linter blocks simple disallowed usages", {

--- a/tests/testthat/test-outer_negation.R
+++ b/tests/testthat/test-outer_negation.R
@@ -1,22 +1,22 @@
 test_that("outer_negation_linter skips allowed usages", {
   linter <- outer_negation_linter()
 
-  expect_lint("x <- any(y)", NULL, linter)
-  expect_lint("y <- all(z)", NULL, linter)
+  expect_no_lint("x <- any(y)", linter)
+  expect_no_lint("y <- all(z)", linter)
 
   # extended usage of any is not covered
-  expect_lint("any(!a & b)", NULL, linter)
-  expect_lint("all(a | !b)", NULL, linter)
+  expect_no_lint("any(!a & b)", linter)
+  expect_no_lint("all(a | !b)", linter)
 
-  expect_lint("any(a, b)", NULL, linter)
-  expect_lint("all(b, c)", NULL, linter)
-  expect_lint("any(!a, b)", NULL, linter)
-  expect_lint("any(!!a)", NULL, linter)
-  expect_lint("any(!!!a)", NULL, linter)
-  expect_lint("all(a, !b)", NULL, linter)
-  expect_lint("any(a, !b, na.rm = TRUE)", NULL, linter)
+  expect_no_lint("any(a, b)", linter)
+  expect_no_lint("all(b, c)", linter)
+  expect_no_lint("any(!a, b)", linter)
+  expect_no_lint("any(!!a)", linter)
+  expect_no_lint("any(!!!a)", linter)
+  expect_no_lint("all(a, !b)", linter)
+  expect_no_lint("any(a, !b, na.rm = TRUE)", linter)
   # ditto when na.rm is passed quoted
-  expect_lint("any(a, !b, 'na.rm' = TRUE)", NULL, linter)
+  expect_no_lint("any(a, !b, 'na.rm' = TRUE)", linter)
 })
 
 test_that("outer_negation_linter blocks simple disallowed usages", {
@@ -40,9 +40,9 @@ test_that("outer_negation_linter doesn't trigger on empty calls", {
   linter <- outer_negation_linter()
 
   # minimal version of issue
-  expect_lint("any()", NULL, linter)
+  expect_no_lint("any()", linter)
   # closer to what was is practically relevant, as another regression test
-  expect_lint("x %>% any()", NULL, linter)
+  expect_no_lint("x %>% any()", linter)
 })
 
 test_that("fix works", {

--- a/tests/testthat/test-package_hooks.R
+++ b/tests/testthat/test-package_hooks.R
@@ -2,7 +2,10 @@ test_that("package_hooks_linter skips allowed usages of packageStartupMessage() 
   linter <- package_hooks_linter()
 
   # allowed in .onAttach, not .onLoad
-  expect_no_lint(".onAttach <- function(lib, pkg) packageStartupMessage('hi')", linter)
+  expect_no_lint(
+    ".onAttach <- function(lib, pkg) packageStartupMessage('hi')",
+    linter
+  )
   # allowed in .onLoad, not .onAttach
   expect_no_lint(".onLoad <- function(lib, pkg) library.dynam()", linter)
 })
@@ -143,8 +146,14 @@ test_that("package_hooks_linter blocks simple disallowed usages of other blocked
 test_that("package_hooks_linter skips valid namespace loading", {
   linter <- package_hooks_linter()
 
-  expect_no_lint(".onAttach <- function(lib, pkg) { requireNamespace('foo') }", linter)
-  expect_no_lint(".onLoad <- function(lib, pkg) {  requireNamespace('foo') }", linter)
+  expect_no_lint(
+    ".onAttach <- function(lib, pkg) { requireNamespace('foo') }",
+    linter
+  )
+  expect_no_lint(
+    ".onLoad <- function(lib, pkg) {  requireNamespace('foo') }",
+    linter
+  )
 })
 
 test_that("package_hooks_linter blocks attaching namespaces", {
@@ -220,7 +229,10 @@ test_that("package_hooks_linter catches usage of library.dynam.unload()", {
     linter
   )
   # expected usage is in .onUnload
-  expect_no_lint(".onUnload <- function(lib) { library.dynam.unload() }", linter)
+  expect_no_lint(
+    ".onUnload <- function(lib) { library.dynam.unload() }",
+    linter
+  )
 })
 
 # test_that("package_hooks_linter detects bad argument names in .onDetach()/.Last.lib()", {

--- a/tests/testthat/test-package_hooks.R
+++ b/tests/testthat/test-package_hooks.R
@@ -2,13 +2,9 @@ test_that("package_hooks_linter skips allowed usages of packageStartupMessage() 
   linter <- package_hooks_linter()
 
   # allowed in .onAttach, not .onLoad
-  expect_lint(
-    ".onAttach <- function(lib, pkg) packageStartupMessage('hi')",
-    NULL,
-    linter
-  )
+  expect_no_lint(".onAttach <- function(lib, pkg) packageStartupMessage('hi')", linter)
   # allowed in .onLoad, not .onAttach
-  expect_lint(".onLoad <- function(lib, pkg) library.dynam()", NULL, linter)
+  expect_no_lint(".onLoad <- function(lib, pkg) library.dynam()", linter)
 })
 
 test_that("package_hooks_linter blocks simple disallowed usages of packageStartupMessage() & library.dynam()", {
@@ -51,11 +47,7 @@ test_that("package_hooks_linter blocks simple disallowed usages of packageStartu
 test_that("package_hooks_linter blocks simple disallowed usages of other blocked messaging functions", {
   linter <- package_hooks_linter()
 
-  expect_lint(
-    ".onLoad <- function(lib, pkg) catr('hi')",
-    NULL,
-    linter
-  )
+  expect_no_lint(".onLoad <- function(lib, pkg) catr('hi')", linter)
 
   for (fn in c(
     "cat",
@@ -151,16 +143,8 @@ test_that("package_hooks_linter blocks simple disallowed usages of other blocked
 test_that("package_hooks_linter skips valid namespace loading", {
   linter <- package_hooks_linter()
 
-  expect_lint(
-    ".onAttach <- function(lib, pkg) { requireNamespace('foo') }",
-    NULL,
-    linter
-  )
-  expect_lint(
-    ".onLoad <- function(lib, pkg) {  requireNamespace('foo') }",
-    NULL,
-    linter
-  )
+  expect_no_lint(".onAttach <- function(lib, pkg) { requireNamespace('foo') }", linter)
+  expect_no_lint(".onLoad <- function(lib, pkg) {  requireNamespace('foo') }", linter)
 })
 
 test_that("package_hooks_linter blocks attaching namespaces", {
@@ -215,11 +199,11 @@ test_that("package_hooks_linter blocks attaching namespaces", {
 test_that("package_hooks_linter skips valid .onDetach() and .Last.lib()", {
   linter <- package_hooks_linter()
 
-  expect_lint(".onDetach <- function(lib) { }", NULL, linter)
-  expect_lint(".onDetach <- function(libname) { }", NULL, linter)
+  expect_no_lint(".onDetach <- function(lib) { }", linter)
+  expect_no_lint(".onDetach <- function(libname) { }", linter)
 
-  expect_lint(".Last.lib <- function(lib) { }", NULL, linter)
-  expect_lint(".Last.lib <- function(libname) { }", NULL, linter)
+  expect_no_lint(".Last.lib <- function(lib) { }", linter)
+  expect_no_lint(".Last.lib <- function(libname) { }", linter)
 })
 
 test_that("package_hooks_linter catches usage of library.dynam.unload()", {
@@ -236,11 +220,7 @@ test_that("package_hooks_linter catches usage of library.dynam.unload()", {
     linter
   )
   # expected usage is in .onUnload
-  expect_lint(
-    ".onUnload <- function(lib) { library.dynam.unload() }",
-    NULL,
-    linter
-  )
+  expect_no_lint(".onUnload <- function(lib) { library.dynam.unload() }", linter)
 })
 
 # test_that("package_hooks_linter detects bad argument names in .onDetach()/.Last.lib()", {

--- a/tests/testthat/test-paste.R
+++ b/tests/testthat/test-paste.R
@@ -1,13 +1,13 @@
 test_that("paste_linter skips allowed usages for sep=''", {
   linter <- paste_linter()
 
-  expect_lint("paste('a', 'b', 'c')", NULL, linter)
-  expect_lint("paste('a', 'b', 'c', sep = ',')", NULL, linter)
-  expect_lint("paste('a', 'b', collapse = '')", NULL, linter)
-  expect_lint("cat(paste('a', 'b'), sep = '')", NULL, linter)
-  expect_lint("sep <- ''; paste('a', sep)", NULL, linter)
-  expect_lint("paste(sep = ',', '', 'a')", NULL, linter)
-  expect_lint("paste0('a', 'b', 'c')", NULL, linter)
+  expect_no_lint("paste('a', 'b', 'c')", linter)
+  expect_no_lint("paste('a', 'b', 'c', sep = ',')", linter)
+  expect_no_lint("paste('a', 'b', collapse = '')", linter)
+  expect_no_lint("cat(paste('a', 'b'), sep = '')", linter)
+  expect_no_lint("sep <- ''; paste('a', sep)", linter)
+  expect_no_lint("paste(sep = ',', '', 'a')", linter)
+  expect_no_lint("paste0('a', 'b', 'c')", linter)
 })
 
 test_that("paste_linter blocks simple disallowed usages for sep=''", {
@@ -27,23 +27,23 @@ test_that("paste_linter blocks simple disallowed usages for sep=''", {
 test_that("paste_linter skips allowed usages for collapse=', '", {
   linter <- paste_linter()
 
-  expect_lint("paste('a', 'b', 'c')", NULL, linter)
-  expect_lint("paste(x, sep = ', ')", NULL, linter)
-  expect_lint("paste(x, collapse = ',')", NULL, linter)
-  expect_lint("paste(foo(x), collapse = '/')", NULL, linter)
+  expect_no_lint("paste('a', 'b', 'c')", linter)
+  expect_no_lint("paste(x, sep = ', ')", linter)
+  expect_no_lint("paste(x, collapse = ',')", linter)
+  expect_no_lint("paste(foo(x), collapse = '/')", linter)
   # harder to catch statically
-  expect_lint("collapse <- ', '; paste(x, collapse = collapse)", NULL, linter)
+  expect_no_lint("collapse <- ', '; paste(x, collapse = collapse)", linter)
 
   # paste(..., sep=sep, collapse=", ") is not a trivial swap to toString
-  expect_lint("paste(x, y, sep = '.', collapse = ', ')", NULL, linter)
+  expect_no_lint("paste(x, y, sep = '.', collapse = ', ')", linter)
   # any call involving ...length() > 1 will implicitly use the default sep
-  expect_lint("paste(x, y, collapse = ', ')", NULL, linter)
-  expect_lint("paste0(x, y, collapse = ', ')", NULL, linter)
+  expect_no_lint("paste(x, y, collapse = ', ')", linter)
+  expect_no_lint("paste0(x, y, collapse = ', ')", linter)
 
-  expect_lint("toString(x)", NULL, linter)
+  expect_no_lint("toString(x)", linter)
 
   # string match of ", " is OK -- lint only _exact_ match
-  expect_lint('paste(x, collapse = ", \n")', NULL, linter)
+  expect_no_lint('paste(x, collapse = ", \n")', linter)
 })
 
 test_that("paste_linter blocks simple disallowed usages for collapse=', '", {
@@ -63,14 +63,14 @@ test_that("paste_linter blocks simple disallowed usages for collapse=', '", {
 
 test_that("paste_linter works for raw strings", {
   skip_if_not_r_version("4.0.0")
-  expect_lint("paste(a, b, sep = R'(xyz)')", NULL, paste_linter())
+  expect_no_lint("paste(a, b, sep = R'(xyz)')", paste_linter())
   # expect_lint(
   #   'paste(a, b, sep = R"---[]---")',
   #   'paste0(...) is better than paste(..., sep = "").',
   #   paste_linter()
   # )
 
-  expect_lint("paste(x, collapse = R'(,,)')", NULL, paste_linter())
+  expect_no_lint("paste(x, collapse = R'(,,)')", paste_linter())
   # expect_lint(
   #   'paste(c(a, b, c), collapse = R"-{, }-")',
   #   'toString(.) is more expressive than paste(., collapse = ", ")',
@@ -137,18 +137,18 @@ test_that("paste_linter catches use of paste0 with sep=", {
 test_that("paste_linter ignores non-path cases with paste0", {
   linter <- paste_linter()
 
-  expect_lint("paste0(x, y)", NULL, linter)
-  expect_lint("paste0('abc', 'def')", NULL, linter)
-  expect_lint("paste0('/abc', 'def/')", NULL, linter)
-  expect_lint("paste0(x, 'def/')", NULL, linter)
-  expect_lint("paste0('/abc', y)", NULL, linter)
-  expect_lint("paste0(foo(x), y)", NULL, linter)
-  expect_lint("paste0(foo(x), 'def')", NULL, linter)
+  expect_no_lint("paste0(x, y)", linter)
+  expect_no_lint("paste0('abc', 'def')", linter)
+  expect_no_lint("paste0('/abc', 'def/')", linter)
+  expect_no_lint("paste0(x, 'def/')", linter)
+  expect_no_lint("paste0('/abc', y)", linter)
+  expect_no_lint("paste0(foo(x), y)", linter)
+  expect_no_lint("paste0(foo(x), 'def')", linter)
 
   # these might be a different lint (as.character instead, e.g.) but not here
-  expect_lint("paste0(x)", NULL, linter)
-  expect_lint("paste0('a')", NULL, linter)
-  expect_lint("paste0('a', 1)", NULL, linter)
+  expect_no_lint("paste0(x)", linter)
+  expect_no_lint("paste0('a')", linter)
+  expect_no_lint("paste0('a', 1)", linter)
 })
 
 # test_that("paste_linter detects paths built with '/' and paste0", {
@@ -164,10 +164,10 @@ test_that("paste_linter ignores non-path cases with paste0", {
 test_that("paste_linter skips initial/terminal '/' and repeated '/' for paths", {
   linter <- paste_linter()
 
-  expect_lint("paste0('/', x)", NULL, linter)
-  expect_lint("paste0(x, '/')", NULL, linter)
-  expect_lint("paste0(x, '//hey/', y)", NULL, linter)
-  expect_lint("paste0(x, '/hey//', y)", NULL, linter)
+  expect_no_lint("paste0('/', x)", linter)
+  expect_no_lint("paste0(x, '/')", linter)
+  expect_no_lint("paste0(x, '//hey/', y)", linter)
+  expect_no_lint("paste0(x, '/hey//', y)", linter)
 })
 
 # test_that("paste_linter doesn't skip all initial/terminal '/' for paths", {
@@ -240,8 +240,8 @@ test_that("paste0(collapse=...) is caught", {
   linter <- paste_linter()
   lint_msg <- "Use paste(), not paste0(), to collapse a character vector when sep= is not used."
 
-  expect_lint("paste(x, collapse = '')", NULL, linter)
-  expect_lint("paste0(a, b, collapse = '')", NULL, linter)
+  expect_no_lint("paste(x, collapse = '')", linter)
+  expect_no_lint("paste0(a, b, collapse = '')", linter)
   # pass-through can pass any number of arguments
   # expect_lint("paste0(..., collapse = '')", NULL, linter)
   expect_lint("paste0(x, collapse = '')", lint_msg, linter)

--- a/tests/testthat/test-redundant_equals.R
+++ b/tests/testthat/test-redundant_equals.R
@@ -1,8 +1,8 @@
 test_that("redundant_equals_linter skips allowed usages", {
   # comparisons to non-logical constants
-  expect_lint("x == 1", NULL, redundant_equals_linter())
+  expect_no_lint("x == 1", redundant_equals_linter())
   # comparison to TRUE as a string
-  expect_lint("x != 'TRUE'", NULL, redundant_equals_linter())
+  expect_no_lint("x != 'TRUE'", redundant_equals_linter())
 })
 
 test_that("multiple lints return correct custom messages", {

--- a/tests/testthat/test-redundant_ifelse.R
+++ b/tests/testthat/test-redundant_ifelse.R
@@ -1,13 +1,13 @@
 test_that("redundant_ifelse_linter skips allowed usages", {
   linter <- redundant_ifelse_linter()
 
-  expect_lint("ifelse(x > 5, 0, 2)", NULL, linter)
-  expect_lint("ifelse(x > 5, TRUE, NA)", NULL, linter)
-  expect_lint("ifelse(x > 5, FALSE, NA)", NULL, linter)
-  expect_lint("ifelse(x > 5, TRUE, TRUE)", NULL, linter)
+  expect_no_lint("ifelse(x > 5, 0, 2)", linter)
+  expect_no_lint("ifelse(x > 5, TRUE, NA)", linter)
+  expect_no_lint("ifelse(x > 5, FALSE, NA)", linter)
+  expect_no_lint("ifelse(x > 5, TRUE, TRUE)", linter)
 
-  expect_lint("ifelse(x > 5, 0L, 2L)", NULL, linter)
-  expect_lint("ifelse(x > 5, 0L, 10L)", NULL, linter)
+  expect_no_lint("ifelse(x > 5, 0L, 2L)", linter)
+  expect_no_lint("ifelse(x > 5, 0L, 10L)", linter)
 })
 
 test_that("redundant_ifelse_linter blocks simple disallowed usages", {

--- a/tests/testthat/test-rep_len.R
+++ b/tests/testthat/test-rep_len.R
@@ -2,17 +2,17 @@ test_that("rep_len_linter skips allowed usages", {
   linter <- rep_len_linter()
 
   # only catch length.out usages
-  expect_lint("rep(x, y)", NULL, linter)
-  expect_lint("rep(1:10, 2)", NULL, linter)
-  expect_lint("rep(1:10, 10:1)", NULL, linter)
+  expect_no_lint("rep(x, y)", linter)
+  expect_no_lint("rep(1:10, 2)", linter)
+  expect_no_lint("rep(1:10, 10:1)", linter)
 
   # usage of each is not compatible with rep_len; see ?rep.
-  expect_lint("rep(x, each = 4, length.out = 50)", NULL, linter)
+  expect_no_lint("rep(x, each = 4, length.out = 50)", linter)
   # each is implicitly the 4th positional argument. a very strange usage
   #   (because length.out is ignored), but doesn't hurt to catch it
-  expect_lint("rep(a, b, length.out = c, d)", NULL, linter)
+  expect_no_lint("rep(a, b, length.out = c, d)", linter)
   # ditto for implicit length.out=
-  expect_lint("rep(a, b, c, d)", NULL, linter)
+  expect_no_lint("rep(a, b, c, d)", linter)
 })
 
 test_that("rep_len_linter blocks simple disallowed usages", {

--- a/tests/testthat/test-sample_int.R
+++ b/tests/testthat/test-sample_int.R
@@ -1,13 +1,13 @@
 test_that("sample_int_linter skips allowed usages", {
   linter <- sample_int_linter()
 
-  expect_lint("sample(n, m)", NULL, linter)
-  expect_lint("sample(n, m, TRUE)", NULL, linter)
-  expect_lint("sample(n, m, prob = 1:n/n)", NULL, linter)
-  expect_lint("sample(foo(x), m, TRUE)", NULL, linter)
-  expect_lint("sample(n, replace = TRUE)", NULL, linter)
+  expect_no_lint("sample(n, m)", linter)
+  expect_no_lint("sample(n, m, TRUE)", linter)
+  expect_no_lint("sample(n, m, prob = 1:n/n)", linter)
+  expect_no_lint("sample(foo(x), m, TRUE)", linter)
+  expect_no_lint("sample(n, replace = TRUE)", linter)
 
-  expect_lint("sample(10:1, m)", NULL, linter)
+  expect_no_lint("sample(10:1, m)", linter)
 })
 
 test_that("sample_int_linter blocks simple disallowed usages", {
@@ -41,15 +41,15 @@ test_that("sample_int_linter blocks sample(seq(n)) and sample(seq(1, ...))", {
   # expect_lint("sample(seq(1L, 10, by = 1L), 5)", lint_msg, linter)
 
   # lint doesn't apply when by= is used (except when set to literal 1)
-  expect_lint("sample(seq(1, 10, by = 2), 5)", NULL, linter)
-  expect_lint("sample(seq(1, 10, by = n), 5)", NULL, linter)
+  expect_no_lint("sample(seq(1, 10, by = 2), 5)", linter)
+  expect_no_lint("sample(seq(1, 10, by = n), 5)", linter)
 })
 
 test_that("sample_int_linter catches literal integer/numeric in the first arg", {
   linter <- sample_int_linter()
   lint_msg <- "sample.int(n, m, ...) is preferable to sample(n, m, ...)."
 
-  expect_lint("sample('a', 4)", NULL, linter)
+  expect_no_lint("sample('a', 4)", linter)
   expect_lint("sample(10L, 4)", lint_msg, linter)
   expect_lint("sample(10, 5)", lint_msg, linter)
 })
@@ -57,19 +57,19 @@ test_that("sample_int_linter catches literal integer/numeric in the first arg", 
 test_that("sample_int_linter skips TRUE or FALSE in the first argument", {
   linter <- sample_int_linter()
 
-  expect_lint("sample(replace = TRUE, letters)", NULL, linter)
-  expect_lint("sample(replace = FALSE, letters)", NULL, linter)
+  expect_no_lint("sample(replace = TRUE, letters)", linter)
+  expect_no_lint("sample(replace = FALSE, letters)", linter)
 })
 
 test_that("sample_int_linter skips x$sample() usage", {
   linter <- sample_int_linter()
   lint_msg <- "sample.int(n, m, ...) is preferable to sample(1:n, m, ...)."
 
-  expect_lint("foo$sample(1L)", NULL, linter)
-  expect_lint("foo$sample(1:10)", NULL, linter)
-  expect_lint("foo$sample(seq_len(10L))", NULL, linter)
+  expect_no_lint("foo$sample(1L)", linter)
+  expect_no_lint("foo$sample(1:10)", linter)
+  expect_no_lint("foo$sample(seq_len(10L))", linter)
   # ditto for '@' slot extraction
-  expect_lint("foo@sample(1L)", NULL, linter)
+  expect_no_lint("foo@sample(1L)", linter)
 
   # TODO
   # however, base::sample qualification is still caught

--- a/tests/testthat/test-seq.R
+++ b/tests/testthat/test-seq.R
@@ -1,19 +1,19 @@
 test_that("other : expressions are fine", {
   linter <- seq_linter()
-  expect_lint("1:10", NULL, linter)
-  expect_lint("2:length(x)", NULL, linter)
-  expect_lint("1:(length(x) || 1)", NULL, linter)
-  expect_lint("2L:length(x)", NULL, linter)
+  expect_no_lint("1:10", linter)
+  expect_no_lint("2:length(x)", linter)
+  expect_no_lint("1:(length(x) || 1)", linter)
+  expect_no_lint("2L:length(x)", linter)
 })
 
 test_that("seq_len(...) or seq_along(...) expressions are fine", {
   linter <- seq_linter()
 
-  expect_lint("seq_len(x)", NULL, linter)
-  expect_lint("seq_along(x)", NULL, linter)
+  expect_no_lint("seq_len(x)", linter)
+  expect_no_lint("seq_along(x)", linter)
 
-  expect_lint("seq(2, length(x))", NULL, linter)
-  expect_lint("seq(length(x), 2)", NULL, linter)
+  expect_no_lint("seq(2, length(x))", linter)
+  expect_no_lint("seq(length(x), 2)", linter)
 })
 
 test_that("finds seq(...) expressions", {
@@ -74,28 +74,28 @@ test_that("finds 1:length(...) expressions", {
     lint_msg("seq_len(nrow(...))", "1:nrow(...)"),
     linter
   )
-  expect_lint("2:nrow(x)", NULL, linter)
+  expect_no_lint("2:nrow(x)", linter)
 
   expect_lint(
     "1:ncol(x)",
     lint_msg("seq_len(ncol(...))", "1:ncol(...)"),
     linter
   )
-  expect_lint("2:ncol(x)", NULL, linter)
+  expect_no_lint("2:ncol(x)", linter)
 
   expect_lint(
     "1:NROW(x)",
     lint_msg("seq_len(NROW(...))", "1:NROW(...)"),
     linter
   )
-  expect_lint("2:NROW(x)", NULL, linter)
+  expect_no_lint("2:NROW(x)", linter)
 
   expect_lint(
     "1:NCOL(x)",
     lint_msg("seq_len(NCOL(...))", "1:NCOL(...)"),
     linter
   )
-  expect_lint("2:NCOL(x)", NULL, linter)
+  expect_no_lint("2:NCOL(x)", linter)
 
   # expect_lint(
   #   "1:dim(x)[1L]",
@@ -203,10 +203,10 @@ test_that("seq(1, x) is blocked if x > 0", {
   linter <- seq_linter()
   msg <- "is more efficient"
 
-  expect_lint("seq(1, NA)", NULL, linter)
-  expect_lint("seq(1, -1)", NULL, linter)
-  expect_lint("seq(1, 0)", NULL, linter)
-  expect_lint("seq(2, 5)", NULL, linter)
+  expect_no_lint("seq(1, NA)", linter)
+  expect_no_lint("seq(1, -1)", linter)
+  expect_no_lint("seq(1, 0)", linter)
+  expect_no_lint("seq(2, 5)", linter)
 
   expect_lint("seq(1, 1)", msg, linter)
   expect_lint("seq(1, 1L)", msg, linter)

--- a/tests/testthat/test-sort.R
+++ b/tests/testthat/test-sort.R
@@ -1,17 +1,17 @@
 test_that("sort_linter skips allowed usages", {
   linter <- sort_linter()
 
-  expect_lint("order(y)", NULL, linter)
+  expect_no_lint("order(y)", linter)
 
-  expect_lint("y[order(x)]", NULL, linter)
+  expect_no_lint("y[order(x)]", linter)
 
   # If another function is intercalated, don't fail
-  expect_lint("x[c(order(x))]", NULL, linter)
+  expect_no_lint("x[c(order(x))]", linter)
 
-  expect_lint("x[order(y, x)]", NULL, linter)
-  expect_lint("x[order(x, y)]", NULL, linter)
+  expect_no_lint("x[order(y, x)]", linter)
+  expect_no_lint("x[order(x, y)]", linter)
   # pretty sure this never makes sense, but test anyway
-  expect_lint("x[order(y, na.last = x)]", NULL, linter)
+  expect_no_lint("x[order(y, na.last = x)]", linter)
 })
 
 test_that("sort_linter blocks simple disallowed usages", {
@@ -68,17 +68,17 @@ test_that("sort_linter skips usages calling sort arguments", {
   linter <- sort_linter()
 
   # any arguments to sort --> not compatible
-  expect_lint("sort(x, decreasing = TRUE) == x", NULL, linter)
-  expect_lint("sort(x, na.last = TRUE) != x", NULL, linter)
-  expect_lint("sort(x, method_arg = TRUE) == x", NULL, linter)
+  expect_no_lint("sort(x, decreasing = TRUE) == x", linter)
+  expect_no_lint("sort(x, na.last = TRUE) != x", linter)
+  expect_no_lint("sort(x, method_arg = TRUE) == x", linter)
 })
 
 test_that("sort_linter skips when inputs don't match", {
   linter <- sort_linter()
 
-  expect_lint("sort(x) == y", NULL, linter)
-  expect_lint("sort(x) == foo(x)", NULL, linter)
-  expect_lint("sort(foo(x)) == x", NULL, linter)
+  expect_no_lint("sort(x) == y", linter)
+  expect_no_lint("sort(x) == foo(x)", linter)
+  expect_no_lint("sort(foo(x)) == x", linter)
 })
 
 test_that("sort_linter blocks simple disallowed usages", {

--- a/tests/testthat/test-stopifnot_all.R
+++ b/tests/testthat/test-stopifnot_all.R
@@ -1,5 +1,5 @@
 test_that("stopifnot_all_linter skips allowed usages", {
-  expect_lint("stopifnot(all(x) || any(y))", NULL, stopifnot_all_linter())
+  expect_no_lint("stopifnot(all(x) || any(y))", stopifnot_all_linter())
 })
 
 # TODO

--- a/tests/testthat/test-todo_comment.R
+++ b/tests/testthat/test-todo_comment.R
@@ -2,9 +2,9 @@ test_that("returns the correct linting", {
   linter <- todo_comment_linter()
   lint_msg <- "Remove TODO comments."
 
-  expect_lint('a <- "you#need#to#fixme"', NULL, linter)
-  expect_lint("# tadatodo", NULL, linter)
-  expect_lint("# something todo", NULL, linter)
+  expect_no_lint('a <- "you#need#to#fixme"', linter)
+  expect_no_lint("# tadatodo", linter)
+  expect_no_lint("# something todo", linter)
   expect_lint("#todo", lint_msg, linter)
   expect_lint("cat(x) ### fixme", lint_msg, linter)
   expect_lint(

--- a/tests/testthat/test-undesirable_function.R
+++ b/tests/testthat/test-undesirable_function.R
@@ -1,7 +1,7 @@
 test_that("browser() call detected", {
   linter <- undesirable_function_linter()
   expect_lint("browser()", "Function \"browser()\" is undesirable", linter)
-  expect_lint("#browser()", NULL, linter)
+  expect_no_lint("#browser()", linter)
 })
 
 test_that("browser() has no fix", {
@@ -11,12 +11,12 @@ test_that("browser() has no fix", {
 test_that("debugonce() call detected", {
   linter <- undesirable_function_linter()
   expect_lint("debugonce()", "Function \"debugonce()\" is undesirable", linter)
-  expect_lint("#debugonce()", NULL, linter)
+  expect_no_lint("#debugonce()", linter)
 })
 
 test_that("those names can be used as argument names, not as values", {
   linter <- undesirable_function_linter()
-  expect_lint("foo(browser = TRUE)", NULL, linter)
+  expect_no_lint("foo(browser = TRUE)", linter)
   expect_lint(
     "foo(x = browser())",
     "Function \"browser()\" is undesirable",

--- a/tests/testthat/test-undesirable_operator.R
+++ b/tests/testthat/test-undesirable_operator.R
@@ -2,7 +2,7 @@ test_that("linter returns correct linting", {
   linter <- undesirable_operator_linter()
   msg_assign <- "Avoid undesirable operators `<<-` and `->>`"
 
-  expect_lint("cat(\"10$\")", NULL, linter)
+  expect_no_lint("cat(\"10$\")", linter)
   expect_lint(
     "a <<- log(10)",
     msg_assign,
@@ -18,7 +18,7 @@ test_that("linter returns correct linting", {
 test_that(":: is ok, ::: is not", {
   linter <- undesirable_operator_linter()
   expect_lint("a:::b", "Operator `:::` is undesirable", linter)
-  expect_lint("a::b", NULL, linter)
+  expect_no_lint("a::b", linter)
 })
 
 test_that("undesirable_operator_linter vectorizes messages", {

--- a/tests/testthat/test-unnecessary_nesting.R
+++ b/tests/testthat/test-unnecessary_nesting.R
@@ -2,8 +2,7 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
   linter <- unnecessary_nesting_linter()
 
   # parallel stops() and return()s are OK
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if (A) {
         stop()
@@ -11,13 +10,9 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         stop()
       }
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if (A) {
         return()
@@ -25,16 +20,12 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         return()
       }
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 })
 
 test_that("Multiple if/else statements don't require unnesting", {
   # with further branches, reducing nesting might be less readable
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if (x == 'a') {
         stop()
@@ -44,30 +35,22 @@ test_that("Multiple if/else statements don't require unnesting", {
         stop()
       }
     "
-    ),
-    NULL,
-    unnecessary_nesting_linter()
-  )
+    ), unnecessary_nesting_linter())
 })
 
 test_that("else-less if statements don't lint", {
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if (x == 4) {
         msg <- 'failed'
         stop(msg)
       }
     "
-    ),
-    NULL,
-    unnecessary_nesting_linter()
-  )
+    ), unnecessary_nesting_linter())
 })
 
 test_that("non-terminal expressions are not considered for the logic", {
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if (x == 4) {
         x <- 5
@@ -76,15 +59,11 @@ test_that("non-terminal expressions are not considered for the logic", {
         return(x)
       }
     "
-    ),
-    NULL,
-    unnecessary_nesting_linter()
-  )
+    ), unnecessary_nesting_linter())
 })
 
 test_that("parallels in further nesting are skipped", {
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if (length(bucket) > 1) {
         return(age)
@@ -97,10 +76,7 @@ test_that("parallels in further nesting are skipped", {
         }
       }
     "
-    ),
-    NULL,
-    unnecessary_nesting_linter()
-  )
+    ), unnecessary_nesting_linter())
 })
 
 # TODO: improve support
@@ -208,8 +184,7 @@ test_that("parallels in further nesting are skipped", {
 # })
 
 test_that("unnecessary_nesting_linter skips one-expression if and else clauses", {
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if (TRUE) {
         x
@@ -217,10 +192,7 @@ test_that("unnecessary_nesting_linter skips one-expression if and else clauses",
         y
       }
     "
-    ),
-    NULL,
-    unnecessary_nesting_linter()
-  )
+    ), unnecessary_nesting_linter())
 })
 
 # test_that("unnecessary_nesting_linter skips one-expression while loops", {
@@ -394,20 +366,15 @@ test_that("unnecessary_nesting_linter skips one-expression if and else clauses",
 test_that("unnecessary_nesting_linter skips allowed usages", {
   linter <- unnecessary_nesting_linter()
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if (x && y) {
         1L
       }
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       for (x in 1:3) {
         if (x && y) {
@@ -415,13 +382,9 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         }
       }
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if (x) {
         1L
@@ -429,13 +392,9 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         2L
       }
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if (x) {
         1L
@@ -446,25 +405,17 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         }
       }
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if (if (x) TRUE else FALSE) {
         1L
       }
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if (x) {
         y <- x + 1L
@@ -473,26 +424,18 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         }
       }
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if ((x && y) || (if (x) TRUE else FALSE)) {
         1L
       }
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
   # if there is any additional code between the inner and outer scopes, no lint
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if (x && a) {
         y <- x + 1L
@@ -501,13 +444,9 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         }
       }
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if (x) {
         if (y) {
@@ -516,13 +455,9 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         y <- x + 1L
       }
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if (x) {
         y <- x + 1L
@@ -532,13 +467,9 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         y <- x
       }
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if (x) {
         y <- x + 1L
@@ -549,13 +480,9 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         }
       }
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if (x) {
         {
@@ -566,13 +493,9 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         }
       }
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if (x) {
         {
@@ -583,13 +506,9 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         y <- x + 1L
       }
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if (x) {
         {
@@ -602,13 +521,9 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         }
       }
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if (A) {
         foo()
@@ -620,13 +535,9 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         }
       }
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       if (A) {
         if (B) {
@@ -636,10 +547,7 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         }
       }
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 })
 
 test_that("unnecessary_nesting_linter blocks disallowed usages", {

--- a/tests/testthat/test-unnecessary_nesting.R
+++ b/tests/testthat/test-unnecessary_nesting.R
@@ -2,7 +2,8 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
   linter <- unnecessary_nesting_linter()
 
   # parallel stops() and return()s are OK
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if (A) {
         stop()
@@ -10,9 +11,12 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         stop()
       }
     "
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if (A) {
         return()
@@ -20,12 +24,15 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         return()
       }
     "
-    ), linter)
+    ),
+    linter
+  )
 })
 
 test_that("Multiple if/else statements don't require unnesting", {
   # with further branches, reducing nesting might be less readable
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if (x == 'a') {
         stop()
@@ -35,22 +42,28 @@ test_that("Multiple if/else statements don't require unnesting", {
         stop()
       }
     "
-    ), unnecessary_nesting_linter())
+    ),
+    unnecessary_nesting_linter()
+  )
 })
 
 test_that("else-less if statements don't lint", {
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if (x == 4) {
         msg <- 'failed'
         stop(msg)
       }
     "
-    ), unnecessary_nesting_linter())
+    ),
+    unnecessary_nesting_linter()
+  )
 })
 
 test_that("non-terminal expressions are not considered for the logic", {
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if (x == 4) {
         x <- 5
@@ -59,11 +72,14 @@ test_that("non-terminal expressions are not considered for the logic", {
         return(x)
       }
     "
-    ), unnecessary_nesting_linter())
+    ),
+    unnecessary_nesting_linter()
+  )
 })
 
 test_that("parallels in further nesting are skipped", {
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if (length(bucket) > 1) {
         return(age)
@@ -76,7 +92,9 @@ test_that("parallels in further nesting are skipped", {
         }
       }
     "
-    ), unnecessary_nesting_linter())
+    ),
+    unnecessary_nesting_linter()
+  )
 })
 
 # TODO: improve support
@@ -184,7 +202,8 @@ test_that("parallels in further nesting are skipped", {
 # })
 
 test_that("unnecessary_nesting_linter skips one-expression if and else clauses", {
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if (TRUE) {
         x
@@ -192,7 +211,9 @@ test_that("unnecessary_nesting_linter skips one-expression if and else clauses",
         y
       }
     "
-    ), unnecessary_nesting_linter())
+    ),
+    unnecessary_nesting_linter()
+  )
 })
 
 # test_that("unnecessary_nesting_linter skips one-expression while loops", {
@@ -366,15 +387,19 @@ test_that("unnecessary_nesting_linter skips one-expression if and else clauses",
 test_that("unnecessary_nesting_linter skips allowed usages", {
   linter <- unnecessary_nesting_linter()
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if (x && y) {
         1L
       }
     "
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       for (x in 1:3) {
         if (x && y) {
@@ -382,9 +407,12 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         }
       }
     "
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if (x) {
         1L
@@ -392,9 +420,12 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         2L
       }
     "
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if (x) {
         1L
@@ -405,17 +436,23 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         }
       }
     "
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if (if (x) TRUE else FALSE) {
         1L
       }
     "
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if (x) {
         y <- x + 1L
@@ -424,18 +461,24 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         }
       }
     "
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if ((x && y) || (if (x) TRUE else FALSE)) {
         1L
       }
     "
-    ), linter)
+    ),
+    linter
+  )
 
   # if there is any additional code between the inner and outer scopes, no lint
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if (x && a) {
         y <- x + 1L
@@ -444,9 +487,12 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         }
       }
     "
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if (x) {
         if (y) {
@@ -455,9 +501,12 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         y <- x + 1L
       }
     "
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if (x) {
         y <- x + 1L
@@ -467,9 +516,12 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         y <- x
       }
     "
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if (x) {
         y <- x + 1L
@@ -480,9 +532,12 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         }
       }
     "
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if (x) {
         {
@@ -493,9 +548,12 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         }
       }
     "
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if (x) {
         {
@@ -506,9 +564,12 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         y <- x + 1L
       }
     "
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if (x) {
         {
@@ -521,9 +582,12 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         }
       }
     "
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if (A) {
         foo()
@@ -535,9 +599,12 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         }
       }
     "
-    ), linter)
+    ),
+    linter
+  )
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       if (A) {
         if (B) {
@@ -547,7 +614,9 @@ test_that("unnecessary_nesting_linter skips allowed usages", {
         }
       }
     "
-    ), linter)
+    ),
+    linter
+  )
 })
 
 test_that("unnecessary_nesting_linter blocks disallowed usages", {

--- a/tests/testthat/test-unreachable_code.R
+++ b/tests/testthat/test-unreachable_code.R
@@ -1,9 +1,5 @@
 test_that("unreachable_code_linter works in simple function", {
-  expect_lint(
-    "foo <- function(bar) { \nreturn(bar)\n }",
-    NULL,
-    "unreachable_code"
-  )
+  expect_no_lint("foo <- function(bar) { \nreturn(bar)\n }", "unreachable_code")
 })
 
 test_that("unreachable_code_linter works in sub expressions", {
@@ -157,15 +153,11 @@ test_that("unreachable_code_linter works with next and break in sub expressions"
 })
 
 test_that("unreachable_code_linter ignores expressions that aren't functions", {
-  expect_lint("x + 1", NULL, "unreachable_code")
+  expect_no_lint("x + 1", "unreachable_code")
 })
 
 test_that("unreachable_code_linter ignores anonymous/inline functions", {
-  expect_lint(
-    "lapply(rnorm(10), function(x) x + 1)",
-    NULL,
-    "unreachable_code"
-  )
+  expect_no_lint("lapply(rnorm(10), function(x) x + 1)", "unreachable_code")
 })
 
 test_that("unreachable_code_linter passes on multi-line functions", {
@@ -175,7 +167,7 @@ test_that("unreachable_code_linter passes on multi-line functions", {
       return(y)
     }
   "
-  expect_lint(lines, NULL, "unreachable_code")
+  expect_no_lint(lines, "unreachable_code")
 })
 
 # TODO
@@ -315,8 +307,7 @@ test_that("unreachable_code_linter finds code after stop()", {
 test_that("unreachable_code_linter ignores code after foo$stop(), which might be stopping a subprocess, for example", {
   linter <- "unreachable_code"
 
-  expect_lint(
-    trim_some(
+  expect_no_lint(trim_some(
       "
       foo <- function(x) {
         bar <- get_process()
@@ -324,12 +315,8 @@ test_that("unreachable_code_linter ignores code after foo$stop(), which might be
         TRUE
       }
     "
-    ),
-    NULL,
-    linter
-  )
-  expect_lint(
-    trim_some(
+    ), linter)
+  expect_no_lint(trim_some(
       "
       foo <- function(x) {
         bar <- get_process()
@@ -337,10 +324,7 @@ test_that("unreachable_code_linter ignores code after foo$stop(), which might be
         TRUE
       }
     "
-    ),
-    NULL,
-    linter
-  )
+    ), linter)
 })
 
 test_that("unreachable_code_linter identifies unreachable code in conditional loops", {
@@ -521,14 +505,14 @@ test_that("unreachable_code_linter identifies unreachable code in mixed conditio
 # })
 
 test_that("Do not lint inline else after stop", {
-  expect_lint("if (x > 3L) stop() else x + 3", NULL, "unreachable_code")
+  expect_no_lint("if (x > 3L) stop() else x + 3", "unreachable_code")
 })
 
 test_that("Do not lint inline else after stop in inline function", {
   linter <- "unreachable_code"
 
-  expect_lint("function(x) if (x > 3L) stop() else x + 3", NULL, linter)
-  expect_lint("function(x) if (x > 3L) { stop() } else {x + 3}", NULL, linter)
+  expect_no_lint("function(x) if (x > 3L) stop() else x + 3", linter)
+  expect_no_lint("function(x) if (x > 3L) { stop() } else {x + 3}", linter)
 })
 
 # test_that("Do not lint inline else after stop in inline lambda function", {
@@ -546,11 +530,7 @@ test_that("unreachable_code is deactivated by default", {
     "Code and comments coming after",
     "unreachable_code"
   )
-  expect_lint(
-    "foo <- function(bar) { \nreturn(bar)\n 1 + 1}",
-    NULL,
-    NULL
-  )
+  expect_no_lint("foo <- function(bar) { \nreturn(bar)\n 1 + 1}", NULL)
 
   create_local_package()
   setup_flir()

--- a/tests/testthat/test-unreachable_code.R
+++ b/tests/testthat/test-unreachable_code.R
@@ -307,7 +307,8 @@ test_that("unreachable_code_linter finds code after stop()", {
 test_that("unreachable_code_linter ignores code after foo$stop(), which might be stopping a subprocess, for example", {
   linter <- "unreachable_code"
 
-  expect_no_lint(trim_some(
+  expect_no_lint(
+    trim_some(
       "
       foo <- function(x) {
         bar <- get_process()
@@ -315,8 +316,11 @@ test_that("unreachable_code_linter ignores code after foo$stop(), which might be
         TRUE
       }
     "
-    ), linter)
-  expect_no_lint(trim_some(
+    ),
+    linter
+  )
+  expect_no_lint(
+    trim_some(
       "
       foo <- function(x) {
         bar <- get_process()
@@ -324,7 +328,9 @@ test_that("unreachable_code_linter ignores code after foo$stop(), which might be
         TRUE
       }
     "
-    ), linter)
+    ),
+    linter
+  )
 })
 
 test_that("unreachable_code_linter identifies unreachable code in conditional loops", {

--- a/tests/testthat/test-which_grepl.R
+++ b/tests/testthat/test-which_grepl.R
@@ -1,6 +1,6 @@
 test_that("which_grepl_linter skips allowed usages", {
   # this _could_ be combined as p1|p2, but often it's cleaner to read this way
-  expect_lint("which(grepl(p1, x) | grepl(p2, x))", NULL, which_grepl_linter())
+  expect_no_lint("which(grepl(p1, x) | grepl(p2, x))", which_grepl_linter())
 })
 
 test_that("which_grepl_linter blocks simple disallowed usages", {


### PR DESCRIPTION
Part of #100 