### PR TITLE
chore: Remove `rex` dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,6 @@ Suggests:
     glue,
     knitr,
     patrick,
-    rex,
     rlang,
     rmarkdown,
     rstudioapi,


### PR DESCRIPTION
Part of #100 

Only used in tests that are commented out I think.