### PR TITLE
chore: Add "lintr authors" to LICENSE, LICENSE.md, and DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,10 +3,11 @@ Type: Package
 Title: Find and Fix Lints in R Code
 Version: 0.5.0.9000
 Authors@R:
-    person(given = "Etienne",
-           family = "Bacher",
-           role = c("aut", "cre", "cph"),
-           email = "etienne.bacher@protonmail.com")
+    c(person(given = "Etienne",
+             family = "Bacher",
+             role = c("aut", "cre", "cph"),
+             email = "etienne.bacher@protonmail.com"),
+      person("lintr authors", role = "aut"))
 Description: Lints are code patterns that are not optimal because they are
     inefficient, forget corner cases, or are less readable. 'flir' provides a
     small set of functions to detect those lints and automatically fix them.

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,5 @@
-YEAR: 2024
+YEAR: 2025
 COPYRIGHT HOLDER: flir authors
+
+YEAR: 2025
+COPYRIGHT HOLDER: lintr authors

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
 # MIT License
 
-Copyright (c) 2024 flir authors
+Copyright (c) 2025 flir authors  
+Copyright (c) 2025 lintr authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
To comply with MIT license requirement since
{flir} copies over documentation, messages, and unit tests from {lintr}.

Note the two trailing spaces after `Copyright (c) 2025 flir authors` in `LICENSE.md` are deliberate to force a line break so each copyright appears in a separate line in both markdown code and html output.

fixes #103