### PR TITLE
fix: Find the root path in `*_text()` functions when the project is not an RStudio project or an R package

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## New features
 
-* New linters: 
+* New linters:
 
   + `expect_s3_class_linter()` (@trevorld, #110)
   + `expect_s4_class_linter()` (@trevorld, #109)
@@ -11,14 +11,17 @@
 
 * New vignette "Tips and tricks" that lists some solutions for problems one may
   encounter when writing new rules (#94).
-  
+
 ## Bug fixes
 
 * When using external rules with the `with-<pkg>` syntax, if the YAML file
-  contains several rules separated by "---", then `flir` would only use the 
-  first one. This is now fixed (#95). 
-  
+  contains several rules separated by "---", then `flir` would only use the
+  first one. This is now fixed (#95).
+
 * `list_linters()` now uses `path = "."` by default (#99).
+
+* `lint_text()` and `fix_text()` now work correctly with custom rules when the
+  working directory is neither an R package nor an RStudio project (#119).
 
 ## Changes
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -229,10 +229,12 @@ uses_flir <- function(path = ".") {
     }
   }
   tryCatch(
-    path <- rprojroot::find_root(
-      rprojroot::is_rstudio_project | rprojroot::is_r_package,
-      path = path
-    ),
+    {
+      path <- rprojroot::find_root(
+        rprojroot::is_rstudio_project | rprojroot::is_r_package,
+        path = path
+      )
+    },
     error = function(e) return(FALSE)
   )
   flir_dir <- fs::path(path, "flir")
@@ -248,11 +250,15 @@ get_custom_linters <- function(path = ".") {
     }
   }
   tryCatch(
-    path <- rprojroot::find_root(
-      rprojroot::is_rstudio_project | rprojroot::is_r_package,
-      path = path
-    ),
-    error = function(e) return(FALSE)
+    {
+      path <- rprojroot::find_root(
+        rprojroot::is_rstudio_project | rprojroot::is_r_package,
+        path = path
+      )
+    },
+    error = function(e) {
+      path <<- "."
+    }
   )
   flir_dir <- fs::path(path, "flir")
   if (

--- a/tests/testthat/test-custom_linters.R
+++ b/tests/testthat/test-custom_linters.R
@@ -1,5 +1,65 @@
-test_that("users can define custom linters", {
+test_that("users can define custom linters in a package", {
   create_local_package()
+  setup_flir()
+  fs::dir_create("flir/rules/custom")
+  fs::dir_create("dir1/dir2")
+
+  cat(
+    "id: foobar
+language: r
+severity: warning
+rule:
+  pattern: unique(length($VAR))
+fix: length(unique(~~VAR~~))
+message: Most likely an error
+",
+    file = "flir/rules/custom/AAAAAAAAA.yml"
+  )
+
+  cat("x <- function() { \nunique(length(x))\n}", file = "dir1/dir2/foo.R")
+
+  config <- yaml::read_yaml("flir/config.yml")
+  config$keep <- c(config$keep, "AAAAAAAAA")
+  yaml::write_yaml(config, "flir/config.yml")
+  withr::with_envvar(
+    new = c("TESTTHAT" = FALSE, "GITHUB_ACTIONS" = FALSE),
+    {
+      expect_equal(nrow(lint(use_cache = FALSE, verbose = FALSE)), 1)
+      # Passing a specific file path works with custom linters, #54
+      expect_equal(
+        nrow(lint("dir1/dir2/foo.R", use_cache = FALSE, verbose = FALSE)),
+        1
+      )
+
+      expect_equal(
+        nrow(
+          lint(
+            use_cache = FALSE,
+            linters = list_linters(path = "."),
+            verbose = FALSE
+          )
+        ),
+        0
+      )
+      fix(path = ".", verbose = FALSE)
+    }
+  )
+  expect_true(
+    any(
+      grepl(
+        "length(unique(x))",
+        readLines("dir1/dir2/foo.R", warn = FALSE),
+        fixed = TRUE
+      )
+    )
+  )
+})
+
+# The important part here is that this is a project that is not a package and
+# is not an RStudio project, meaning that rprojroot doesn't find the root of
+# the path, #118.
+test_that("users can define custom linters in a project", {
+  create_local_project()
   setup_flir()
   fs::dir_create("flir/rules/custom")
   fs::dir_create("dir1/dir2")


### PR DESCRIPTION
Fixes #118